### PR TITLE
Feat/request envelope metricsfeat: expose request envelope metrics endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ pycache/
 config.py
 .env
 venv/
+# CI temp logs
+tmp_ci_logs/
+tmp_ci_logs/**/*.txt

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from src.agents.web_fetch_agent import router as fetch_router
 from src.agents.search_agent import router as search_router
 from src.agents.streamfinder.streamfinder import StreamfinderAgent
 from src.agents.identity_agent.store import get_identity_by_handle
+from src.core.request import validate_request_envelope
 from agent_logic import handle_a2a_request, handle_payment_confirmation
 from agent_wallet import AgentWallet
 
@@ -30,6 +31,17 @@ logger = logging.getLogger(__name__)
 
 streamfinder_agent: StreamfinderAgent | None = None
 payment_wallet: AgentWallet | None = None
+REQUEST_ENVELOPE_METRICS = {
+    "valid": 0,
+    "invalid": 0,
+}
+
+
+def record_request_envelope_metric(is_valid: bool) -> None:
+    if is_valid:
+        REQUEST_ENVELOPE_METRICS["valid"] += 1
+    else:
+        REQUEST_ENVELOPE_METRICS["invalid"] += 1
 
 
 def _build_base_url() -> str:
@@ -218,6 +230,10 @@ async def nostr_well_known(request: Request, name: str | None = None):
 @app.post("/a2a")
 async def a2a_endpoint(request: Request):
     body = await request.json()
+    is_valid_envelope = validate_request_envelope(body)
+    record_request_envelope_metric(is_valid_envelope)
+    if not is_valid_envelope:
+        logger.warning("Invalid request envelope received; continuing in compatibility mode")
     method = body.get("method", "")
     params = body.get("params", {})
     request_id = body.get("id", 1)

--- a/main.py
+++ b/main.py
@@ -242,6 +242,11 @@ async def a2a_endpoint(request: Request):
     return {"jsonrpc": "2.0", "result": result, "id": request_id}
 
 
+@app.get("/internal/request-envelope-metrics")
+def get_request_envelope_metrics():
+    return dict(REQUEST_ENVELOPE_METRICS)
+
+
 @app.post("/payment/confirm")
 async def confirm_payment(request: Request):
     body = await request.json()

--- a/src/core/request.py
+++ b/src/core/request.py
@@ -1,0 +1,52 @@
+"""
+Request envelope helpers for agent-to-agent communication.
+
+This module is intentionally non-enforcing scaffolding. It defines a
+standardized request envelope shape and placeholder signature helpers that
+future packets can integrate into runtime paths.
+"""
+
+
+def validate_request_envelope(req: dict) -> bool:
+    """
+    Validate a standardized request envelope.
+
+    Expected structure:
+    {
+        "id": str,
+        "method": str,
+        "params": dict,
+        "sender": str,
+        "signature": str | None,
+        "timestamp": int
+    }
+    """
+    required_keys = {"id", "method", "params", "sender", "signature", "timestamp"}
+    if not isinstance(req, dict):
+        return False
+    if not required_keys.issubset(req.keys()):
+        return False
+    if not isinstance(req.get("id"), str) or not req["id"].strip():
+        return False
+    if not isinstance(req.get("method"), str) or not req["method"].strip():
+        return False
+    if not isinstance(req.get("params"), dict):
+        return False
+    if not isinstance(req.get("sender"), str) or not req["sender"].strip():
+        return False
+    if not isinstance(req.get("timestamp"), int):
+        return False
+    signature = req.get("signature")
+    if signature is not None and not isinstance(signature, str):
+        return False
+    return True
+
+
+def sign_request(req: dict, private_key: str) -> str:
+    """Placeholder signing helper for future crypto integration."""
+    return "stub-signature"
+
+
+def verify_signature(req: dict) -> bool:
+    """Placeholder signature verification helper for future crypto integration."""
+    return True

--- a/tests/test_agents_functionality.py
+++ b/tests/test_agents_functionality.py
@@ -293,3 +293,59 @@ async def test_a2a_endpoint_invalid_legacy_payload_logs_warning_and_continues(ca
     assert "Invalid request envelope received; continuing in compatibility mode" in caplog.text
     assert app_main.REQUEST_ENVELOPE_METRICS["valid"] == 0
     assert app_main.REQUEST_ENVELOPE_METRICS["invalid"] == 1
+
+
+def test_request_envelope_metrics_endpoint_returns_expected_keys():
+    app_main.REQUEST_ENVELOPE_METRICS["valid"] = 0
+    app_main.REQUEST_ENVELOPE_METRICS["invalid"] = 0
+
+    metrics = app_main.get_request_envelope_metrics()
+
+    assert "valid" in metrics
+    assert "invalid" in metrics
+    assert metrics == {"valid": 0, "invalid": 0}
+
+
+def test_request_envelope_metrics_endpoint_returns_copy_and_does_not_mutate_source():
+    app_main.REQUEST_ENVELOPE_METRICS["valid"] = 2
+    app_main.REQUEST_ENVELOPE_METRICS["invalid"] = 3
+
+    metrics = app_main.get_request_envelope_metrics()
+    metrics["valid"] = 999
+
+    assert app_main.REQUEST_ENVELOPE_METRICS["valid"] == 2
+    assert app_main.REQUEST_ENVELOPE_METRICS["invalid"] == 3
+
+
+@pytest.mark.asyncio
+async def test_request_envelope_metrics_endpoint_reflects_previous_a2a_requests():
+    app_main.REQUEST_ENVELOPE_METRICS["valid"] = 0
+    app_main.REQUEST_ENVELOPE_METRICS["invalid"] = 0
+
+    valid_request = AsyncMock()
+    valid_request.json = AsyncMock(
+        return_value={
+            "id": "req-1",
+            "method": "identity.get_identity",
+            "params": {"pubkey": "abc"},
+            "sender": "did:example:alice",
+            "signature": None,
+            "timestamp": 1710000000,
+        }
+    )
+    invalid_request = AsyncMock()
+    invalid_request.json = AsyncMock(
+        return_value={
+            "id": 2,
+            "method": "identity.get_identity",
+            "params": {"pubkey": "abc"},
+        }
+    )
+
+    with patch("main.handle_a2a_request", AsyncMock(return_value={"ok": True})):
+        await app_main.a2a_endpoint(valid_request)
+        await app_main.a2a_endpoint(invalid_request)
+
+    metrics = app_main.get_request_envelope_metrics()
+    assert metrics["valid"] == 1
+    assert metrics["invalid"] == 1

--- a/tests/test_agents_functionality.py
+++ b/tests/test_agents_functionality.py
@@ -6,6 +6,25 @@ Test script to verify PolyglotAgent and CoordinatorAgent functionality
 import sys
 import os
 import asyncio
+import logging
+import importlib
+from unittest.mock import Mock
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.core.payment import (
+    FedimintPaymentProvider,
+    LNbitsPaymentProvider,
+    PaymentProvider,
+    get_payment_provider,
+)
+from src.core.request import (
+    sign_request,
+    validate_request_envelope,
+    verify_signature,
+)
+app_main = importlib.import_module("main")
 sys.path.append('.')
 
 async def test_polyglot_agent():
@@ -115,3 +134,162 @@ async def main():
 
 if __name__ == "__main__":
     asyncio.run(main())
+
+
+def test_lnbits_payment_provider_protocol_and_methods():
+    mock_client = Mock()
+    mock_client.create_invoice.return_value = {"payment_hash": "hash_1", "bolt11": "lnbc1"}
+    mock_client.check_invoice.return_value = True
+    mock_client.pay_invoice.return_value = True
+
+    provider = LNbitsPaymentProvider(mock_client)
+    assert isinstance(provider, PaymentProvider)
+    assert provider.create_invoice(100, "memo") == {"payment_hash": "hash_1", "bolt11": "lnbc1"}
+    assert provider.verify_payment("hash_1") is True
+    assert provider.receive("token", 100) is True
+    assert provider.send(100, "lnbc_dest") is True
+
+
+def test_fedimint_payment_provider_protocol_and_methods():
+    mock_wallet = Mock()
+    mock_wallet.create_invoice.return_value = {"invoice": "fm_inv_1"}
+    mock_wallet.verify_invoice.return_value = True
+    mock_wallet.receive_token.return_value = True
+    mock_wallet.send_token.return_value = True
+
+    provider = FedimintPaymentProvider(mock_wallet)
+    assert isinstance(provider, PaymentProvider)
+    assert provider.create_invoice(50, "memo") == {"invoice": "fm_inv_1"}
+    assert provider.verify_payment("fm_inv_1") is True
+    assert provider.receive("ecash_token", 50) is True
+    assert provider.send(50, "destination") is True
+
+
+def test_get_payment_provider_factory():
+    mock_client = Mock()
+    lnbits_provider = get_payment_provider("lnbits", mock_client)
+    assert isinstance(lnbits_provider, LNbitsPaymentProvider)
+
+    mock_wallet = Mock()
+    fedimint_provider = get_payment_provider("fedimint", mock_wallet)
+    assert isinstance(fedimint_provider, FedimintPaymentProvider)
+
+
+def test_validate_request_envelope_valid_payload_passes():
+    req = {
+        "id": "req-1",
+        "method": "agent.translate",
+        "params": {"text": "hello"},
+        "sender": "did:example:alice",
+        "signature": None,
+        "timestamp": 1710000000,
+    }
+    assert validate_request_envelope(req) is True
+
+
+def test_validate_request_envelope_missing_method_fails():
+    req = {
+        "id": "req-1",
+        "params": {"text": "hello"},
+        "sender": "did:example:alice",
+        "signature": None,
+        "timestamp": 1710000000,
+    }
+    assert validate_request_envelope(req) is False
+
+
+def test_validate_request_envelope_invalid_params_type_fails():
+    req = {
+        "id": "req-1",
+        "method": "agent.translate",
+        "params": ["not", "a", "dict"],
+        "sender": "did:example:alice",
+        "signature": None,
+        "timestamp": 1710000000,
+    }
+    assert validate_request_envelope(req) is False
+
+
+def test_validate_request_envelope_missing_timestamp_fails():
+    req = {
+        "id": "req-1",
+        "method": "agent.translate",
+        "params": {"text": "hello"},
+        "sender": "did:example:alice",
+        "signature": None,
+    }
+    assert validate_request_envelope(req) is False
+
+
+def test_validate_request_envelope_signature_present_still_passes():
+    req = {
+        "id": "req-1",
+        "method": "agent.translate",
+        "params": {"text": "hello"},
+        "sender": "did:example:alice",
+        "signature": "signed-payload",
+        "timestamp": 1710000000,
+    }
+    assert validate_request_envelope(req) is True
+
+
+def test_request_signature_helpers_are_non_enforcing_stubs():
+    req = {
+        "id": "req-2",
+        "method": "agent.translate",
+        "params": {"text": "hello"},
+        "sender": "did:example:alice",
+        "signature": None,
+        "timestamp": 1710000001,
+    }
+    assert sign_request(req, "private-key") == "stub-signature"
+    assert verify_signature(req) is True
+
+
+@pytest.mark.asyncio
+async def test_a2a_endpoint_valid_envelope_is_accepted():
+    app_main.REQUEST_ENVELOPE_METRICS["valid"] = 0
+    app_main.REQUEST_ENVELOPE_METRICS["invalid"] = 0
+    request = AsyncMock()
+    request.json = AsyncMock(
+        return_value={
+            "id": "req-1",
+            "method": "identity.get_identity",
+            "params": {"pubkey": "abc"},
+            "sender": "did:example:alice",
+            "signature": None,
+            "timestamp": 1710000000,
+        }
+    )
+
+    with patch("main.handle_a2a_request", AsyncMock(return_value={"ok": True})) as handle_mock:
+        response = await app_main.a2a_endpoint(request)
+
+    assert response == {"jsonrpc": "2.0", "result": {"ok": True}, "id": "req-1"}
+    handle_mock.assert_awaited_once_with("identity.get_identity", {"pubkey": "abc"})
+    assert app_main.REQUEST_ENVELOPE_METRICS["valid"] == 1
+    assert app_main.REQUEST_ENVELOPE_METRICS["invalid"] == 0
+
+
+@pytest.mark.asyncio
+async def test_a2a_endpoint_invalid_legacy_payload_logs_warning_and_continues(caplog):
+    app_main.REQUEST_ENVELOPE_METRICS["valid"] = 0
+    app_main.REQUEST_ENVELOPE_METRICS["invalid"] = 0
+    request = AsyncMock()
+    request.json = AsyncMock(
+        return_value={
+            "method": "identity.get_identity",
+            "params": {"pubkey": "abc"},
+            "id": 7,
+        }
+    )
+
+    with patch("main.handle_a2a_request", AsyncMock(return_value={"ok": "legacy"})) as handle_mock:
+        with caplog.at_level(logging.WARNING):
+            response = await app_main.a2a_endpoint(request)
+
+    assert response == {"jsonrpc": "2.0", "result": {"ok": "legacy"}, "id": 7}
+    handle_mock.assert_awaited_once_with("identity.get_identity", {"pubkey": "abc"})
+    assert "Invalid request envelope received; continuing in compatibility mode" in caplog.text
+    assert app_main.REQUEST_ENVELOPE_METRICS["valid"] == 0
+    assert app_main.REQUEST_ENVELOPE_METRICS["invalid"] == 1


### PR DESCRIPTION
This PR exposes read-only request envelope metrics at:

GET /internal/request-envelope-metrics

It returns a copy of the in-process REQUEST_ENVELOPE_METRICS dict and does not modify /a2a response behavior.

Known unrelated baseline issues:
- Integration collect-only currently fails due to existing nostr dependency import issue.
- BaseAgent wallet compatibility issue should be handled in a separate fix branch.