### PR TITLE
feat: persist Nostr identity and restore Python 3.13 runtime support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,44 @@
+# BitAgent — example environment configuration
+# Copy to .env and fill in your values.
+
+# ── Required ─────────────────────────────────────────────────────────────────
+
+# LNbits instance URL and invoice/admin API key
+LNBITS_URL=https://your-lnbits-instance.com
+LNBITS_API_KEY=your_lnbits_api_key_here
+
+# ── Nostr identity ────────────────────────────────────────────────────────────
+
+# 64-character lowercase hex secp256k1 private key.
+# When set, the node uses a stable Nostr identity across restarts (persistent mode).
+# When absent, a new ephemeral keypair is generated on each startup.
+#
+# Generate a key:
+#   python -c "from nostr.key import PrivateKey; print(PrivateKey().raw_secret.hex())"
+#
+# NOSTR_PRIVATE_KEY=
+
+# ── Optional payments ─────────────────────────────────────────────────────────
+
+# Fedimint ecash (second payment path alongside Lightning)
+# FEDIMINT_CLIENTD_URL=http://localhost:3333
+# FEDIMINT_CLIENTD_PASSWORD=your_fedimint_password
+
+# ── Server ────────────────────────────────────────────────────────────────────
+
+# Comma-separated list of allowed CORS origins, or * for open access
+# ALLOWED_ORIGINS=http://localhost:3000,https://your-frontend.com
+
+PORT=8000
+HOST=0.0.0.0
+LOG_LEVEL=INFO
+
+# Public base URL used in Nostr agent announcements (auto-detected on Railway)
+# PUBLIC_URL=https://your-domain.com
+
+# ── Identity gate (optional, off by default) ──────────────────────────────────
+
+# Require callers of streamfinder.search to have a registered NIP-05 identity
+# IDENTITY_REQUIRE_FOR_PAID_SERVICES=false
+# IDENTITY_MIN_TRUST_SCORE=0.25
+# IDENTITY_FREE_QUERIES=false

--- a/src/network/p2p_discovery.py
+++ b/src/network/p2p_discovery.py
@@ -18,19 +18,30 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-# Nostr imports (optional dependency)
+# Nostr imports (optional dependency).
+# RelayManager is intentionally excluded: python-nostr's relay.py uses a
+# mutable dataclass default (RelayPolicy) that is rejected by Python 3.13+.
+# We replace relay connectivity with a minimal aiohttp WebSocket publisher.
 NOSTR_AVAILABLE = False
 NOSTR_IMPORT_ERROR = None
 try:
     from nostr.event import Event, EventKind
     from nostr.key import PrivateKey, PublicKey
-    from nostr.relay_manager import RelayManager
     from nostr.filter import Filter, Filters
     from nostr.message_type import ClientMessageType
     NOSTR_AVAILABLE = True
 except Exception as e:
     NOSTR_IMPORT_ERROR = e
     logger.warning("Nostr support unavailable; continuing with DHT-only discovery: %s", e)
+
+
+async def _ws_publish(url: str, msg: str) -> None:
+    """Send one NIP-01 message to a single relay WebSocket, best-effort."""
+    timeout = aiohttp.ClientTimeout(connect=5, total=8)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.ws_connect(url, ssl=False, heartbeat=None) as ws:
+            await ws.send_str(msg)
+            await asyncio.sleep(0.3)  # brief wait for relay ACK
 
 class DiscoveryProtocol(Enum):
     NOSTR = "nostr"
@@ -199,21 +210,15 @@ class EnhancedNostrDiscovery:
             )
 
         self.public_key = self.private_key.public_key
-        self.relay_manager = RelayManager()
         self.agent_cache = {}
         self.reputation_scores = {}
-        
-        # Add default relays
         self.relays = [
             "wss://relay.damus.io",
             "wss://relay.snort.social",
             "wss://nos.lol",
             "wss://nostr.wine",
-            "wss://relay.nostr.band"
+            "wss://relay.nostr.band",
         ]
-        
-        for relay in self.relays:
-            self.relay_manager.add_relay(relay)
     
     async def broadcast_agent(self, agent_info: AgentInfo):
         """Broadcast agent information via Nostr."""
@@ -230,21 +235,20 @@ class EnhancedNostrDiscovery:
         }
         
         event = Event(
-            pubkey=self.public_key.hex(),
-            kind=30078,  # Custom agent announcement kind
+            public_key=self.public_key.hex(),
+            kind=30078,
             content=json.dumps(content),
             tags=[
                 ["t", "bitagent"],
                 ["t", "agent-discovery"],
                 ["service", *agent_info.services],
-                ["endpoint", agent_info.endpoint]
-            ]
+                ["endpoint", agent_info.endpoint],
+            ],
         )
-        
+
         self.private_key.sign_event(event)
-        
         await self._publish_event(event)
-        logging.info(f"Broadcasted agent {agent_info.name} via Nostr")
+        logger.info("Broadcasted agent %s via Nostr", agent_info.name)
     
     async def discover_agents(self, query: DiscoveryQuery) -> List[AgentInfo]:
         """Discover agents using Nostr."""
@@ -292,40 +296,19 @@ class EnhancedNostrDiscovery:
         reputation = self.reputation_scores.get(agent_info.agent_id, 0.0)
         return reputation >= 0.0  # Basic filtering - can be enhanced
     
-    async def _publish_event(self, event: Event):
-        """Publish event to Nostr relays."""
-        self.relay_manager.open_connections({"cert_reqs": 0})
-        await asyncio.sleep(1.25)  # Let relays connect
-        
-        msg = json.dumps([ClientMessageType.EVENT, event.to_dict()])
-        for relay in self.relay_manager.relays.values():
-            relay.send_message(msg)
-        
-        await asyncio.sleep(2)
-        self.relay_manager.close_connections()
-    
-    async def _query_events(self, filters: Filters) -> List[Event]:
-        """Query events from Nostr relays."""
-        events = []
-        
-        self.relay_manager.open_connections({"cert_reqs": 0})
-        await asyncio.sleep(1.25)
-        
-        # Subscribe to events
-        subscription_id = f"agent-discovery-{int(time.time())}"
-        msg = json.dumps([ClientMessageType.REQUEST, subscription_id, filters.to_json_array()])
-        
-        for relay in self.relay_manager.relays.values():
-            relay.send_message(msg)
-        
-        # Collect events
-        await asyncio.sleep(5)  # Wait for responses
-        
-        for relay in self.relay_manager.relays.values():
-            events.extend(relay.events)
-        
-        self.relay_manager.close_connections()
-        return events
+    async def _publish_event(self, event: Event) -> None:
+        """Publish a signed Nostr event to all configured relays concurrently."""
+        msg = event.to_message()  # already a complete NIP-01 '["EVENT", {...}]' JSON string
+        tasks = [_ws_publish(url, msg) for url in self.relays]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        failed = sum(1 for r in results if isinstance(r, Exception))
+        if failed:
+            logger.debug("Nostr: %d/%d relay(s) did not acknowledge event", failed, len(self.relays))
+
+    async def _query_events(self, filters) -> List[Event]:
+        """Query events from relays (not yet implemented; returns empty list)."""
+        logger.debug("Nostr: relay query not implemented; returning empty")
+        return []
 
 class P2PDiscoveryManager:
     """Main discovery manager coordinating multiple discovery protocols."""

--- a/src/network/p2p_discovery.py
+++ b/src/network/p2p_discovery.py
@@ -173,7 +173,31 @@ class EnhancedNostrDiscovery:
     def __init__(self, private_key: str = None):
         if not NOSTR_AVAILABLE:
             raise RuntimeError(f"Nostr dependencies unavailable: {NOSTR_IMPORT_ERROR}")
-        self.private_key = PrivateKey(bytes.fromhex(private_key)) if private_key else PrivateKey()
+
+        if private_key:
+            try:
+                self.private_key = PrivateKey(bytes.fromhex(private_key.strip()))
+                logger.info(
+                    "Nostr: persistent identity loaded (pubkey %s...)",
+                    self.private_key.public_key.hex()[:16],
+                )
+            except Exception as e:
+                logger.warning(
+                    "Nostr: NOSTR_PRIVATE_KEY is invalid (%s) — falling back to ephemeral identity",
+                    e,
+                )
+                self.private_key = PrivateKey()
+                logger.info(
+                    "Nostr: ephemeral identity active (pubkey %s...)",
+                    self.private_key.public_key.hex()[:16],
+                )
+        else:
+            self.private_key = PrivateKey()
+            logger.info(
+                "Nostr: NOSTR_PRIVATE_KEY not set — ephemeral identity active (pubkey %s...)",
+                self.private_key.public_key.hex()[:16],
+            )
+
         self.public_key = self.private_key.public_key
         self.relay_manager = RelayManager()
         self.agent_cache = {}

--- a/tests/agents/test_nostr_identity.py
+++ b/tests/agents/test_nostr_identity.py
@@ -1,0 +1,108 @@
+"""
+Tests for persistent vs ephemeral Nostr identity in EnhancedNostrDiscovery.
+Covers: valid persistent key, no-key ephemeral fallback, malformed key fallback.
+
+The python-nostr library's RelayManager fails to import under Python 3.13 due
+to a pydantic-v2 dataclass incompatibility (RelayPolicy mutable default).
+PrivateKey and PublicKey import correctly. Tests therefore patch NOSTR_AVAILABLE
+and inject a mock RelayManager so the constructor's key-handling logic can be
+exercised without the relay stack.
+"""
+
+import logging
+import pytest
+from unittest.mock import patch, MagicMock
+from nostr.key import PrivateKey
+
+import src.network.p2p_discovery as pd_module
+
+_LOG = "src.network.p2p_discovery"
+_NOSTR_AVAIL = "src.network.p2p_discovery.NOSTR_AVAILABLE"
+_RELAY_MGR = "src.network.p2p_discovery.RelayManager"
+
+
+@pytest.fixture(autouse=True)
+def _nostr_env():
+    """Patch NOSTR_AVAILABLE=True and inject a stub RelayManager for every test."""
+    with patch(_NOSTR_AVAIL, True), patch(_RELAY_MGR, MagicMock(), create=True):
+        yield
+
+
+class TestNostrPersistentIdentity:
+    """Valid NOSTR_PRIVATE_KEY → deterministic public key, 'persistent' logged."""
+
+    def test_known_key_produces_correct_pubkey(self):
+        k = PrivateKey()
+        discovery = pd_module.EnhancedNostrDiscovery(k.raw_secret.hex())
+        assert discovery.public_key.hex() == k.public_key.hex()
+
+    def test_same_key_same_pubkey_across_instances(self):
+        k = PrivateKey()
+        key_hex = k.raw_secret.hex()
+        d1 = pd_module.EnhancedNostrDiscovery(key_hex)
+        d2 = pd_module.EnhancedNostrDiscovery(key_hex)
+        assert d1.public_key.hex() == d2.public_key.hex()
+
+    def test_logs_persistent_mode(self, caplog):
+        k = PrivateKey()
+        with caplog.at_level(logging.INFO, logger=_LOG):
+            pd_module.EnhancedNostrDiscovery(k.raw_secret.hex())
+        assert any("persistent" in r.message.lower() for r in caplog.records)
+
+    def test_key_with_surrounding_whitespace_accepted(self):
+        """strip() should handle copy-paste whitespace around the key."""
+        k = PrivateKey()
+        discovery = pd_module.EnhancedNostrDiscovery("  " + k.raw_secret.hex() + "\n")
+        assert discovery.public_key.hex() == k.public_key.hex()
+
+
+class TestNostrEphemeralIdentity:
+    """No NOSTR_PRIVATE_KEY → fresh random keypair, 'ephemeral' logged."""
+
+    def test_no_key_generates_valid_pubkey(self):
+        discovery = pd_module.EnhancedNostrDiscovery()
+        pubkey_hex = discovery.public_key.hex()
+        assert len(pubkey_hex) == 64
+        assert all(c in "0123456789abcdef" for c in pubkey_hex)
+
+    def test_two_instances_have_different_pubkeys(self):
+        d1 = pd_module.EnhancedNostrDiscovery()
+        d2 = pd_module.EnhancedNostrDiscovery()
+        assert d1.public_key.hex() != d2.public_key.hex()
+
+    def test_logs_ephemeral_mode(self, caplog):
+        with caplog.at_level(logging.INFO, logger=_LOG):
+            pd_module.EnhancedNostrDiscovery()
+        assert any("ephemeral" in r.message.lower() for r in caplog.records)
+
+
+class TestNostrMalformedKey:
+    """Invalid NOSTR_PRIVATE_KEY → falls back to ephemeral with a WARNING."""
+
+    def _check_fallback(self, key: str, caplog) -> pd_module.EnhancedNostrDiscovery:
+        with caplog.at_level(logging.WARNING, logger=_LOG):
+            discovery = pd_module.EnhancedNostrDiscovery(key)
+        assert len(discovery.public_key.hex()) == 64
+        assert any("invalid" in r.message.lower() for r in caplog.records)
+        return discovery
+
+    def test_non_hex_string_falls_back(self, caplog):
+        self._check_fallback("not-a-valid-hex-string", caplog)
+
+    def test_too_short_hex_falls_back(self, caplog):
+        self._check_fallback("deadbeef", caplog)  # 4 bytes, need 32
+
+    def test_too_long_hex_falls_back(self, caplog):
+        self._check_fallback("aa" * 33, caplog)  # 33 bytes, need 32
+
+    def test_empty_string_treated_as_absent(self):
+        """Empty string is falsy — goes directly to ephemeral path without warning."""
+        discovery = pd_module.EnhancedNostrDiscovery("")
+        assert len(discovery.public_key.hex()) == 64
+
+    def test_fallback_logs_ephemeral_after_warning(self, caplog):
+        with caplog.at_level(logging.INFO, logger=_LOG):
+            pd_module.EnhancedNostrDiscovery("bad_key_value")
+        messages = [r.message.lower() for r in caplog.records]
+        assert any("invalid" in m for m in messages)
+        assert any("ephemeral" in m for m in messages)

--- a/tests/agents/test_nostr_identity.py
+++ b/tests/agents/test_nostr_identity.py
@@ -1,31 +1,25 @@
 """
 Tests for persistent vs ephemeral Nostr identity in EnhancedNostrDiscovery.
-Covers: valid persistent key, no-key ephemeral fallback, malformed key fallback.
+Covers: valid persistent key, no-key ephemeral fallback, malformed key fallback,
+        unavailable-Nostr error path, and _ws_publish relay helper.
 
-The python-nostr library's RelayManager fails to import under Python 3.13 due
-to a pydantic-v2 dataclass incompatibility (RelayPolicy mutable default).
-PrivateKey and PublicKey import correctly. Tests therefore patch NOSTR_AVAILABLE
-and inject a mock RelayManager so the constructor's key-handling logic can be
-exercised without the relay stack.
+python-nostr's Event/PrivateKey/Filter modules import cleanly under Python 3.13.
+RelayManager was dropped (its relay.py uses a mutable dataclass default rejected
+by Python 3.13); relay connectivity is now handled by _ws_publish via aiohttp.
+NOSTR_AVAILABLE is therefore True at import time — no patching required for the
+happy-path tests.
 """
 
+import asyncio
 import logging
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, AsyncMock, MagicMock
 from nostr.key import PrivateKey
 
 import src.network.p2p_discovery as pd_module
 
 _LOG = "src.network.p2p_discovery"
 _NOSTR_AVAIL = "src.network.p2p_discovery.NOSTR_AVAILABLE"
-_RELAY_MGR = "src.network.p2p_discovery.RelayManager"
-
-
-@pytest.fixture(autouse=True)
-def _nostr_env():
-    """Patch NOSTR_AVAILABLE=True and inject a stub RelayManager for every test."""
-    with patch(_NOSTR_AVAIL, True), patch(_RELAY_MGR, MagicMock(), create=True):
-        yield
 
 
 class TestNostrPersistentIdentity:
@@ -106,3 +100,37 @@ class TestNostrMalformedKey:
         messages = [r.message.lower() for r in caplog.records]
         assert any("invalid" in m for m in messages)
         assert any("ephemeral" in m for m in messages)
+
+
+class TestNostrUnavailable:
+    """When NOSTR_AVAILABLE is False, EnhancedNostrDiscovery raises RuntimeError."""
+
+    def test_raises_when_nostr_unavailable(self):
+        with patch(_NOSTR_AVAIL, False):
+            with pytest.raises(RuntimeError, match="unavailable"):
+                pd_module.EnhancedNostrDiscovery()
+
+    def test_p2p_manager_skips_nostr_when_unavailable(self):
+        with patch(_NOSTR_AVAIL, False):
+            manager = pd_module.P2PDiscoveryManager()
+        assert manager.nostr_discovery is None
+        assert pd_module.DiscoveryProtocol.NOSTR not in manager.discovery_protocols
+
+
+class TestWsPublish:
+    """_ws_publish sends the NIP-01 message over a WebSocket connection."""
+
+    def test_sends_message_to_relay(self):
+        mock_ws = AsyncMock()
+        mock_ws.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_ws.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.ws_connect = MagicMock(return_value=mock_ws)
+
+        with patch("src.network.p2p_discovery.aiohttp.ClientSession", return_value=mock_session):
+            asyncio.run(pd_module._ws_publish("wss://relay.example.com", '["EVENT",{}]'))
+
+        mock_ws.send_str.assert_awaited_once_with('["EVENT",{}]')


### PR DESCRIPTION
## What This PR Changes

Adds persistent Nostr identity support and restores Nostr runtime compatibility under Python 3.13.

## Why This Matters

BitAgent needs a stable network identity across restarts so agents can accumulate trust, reputation, and discoverability. Persistent identity was added in Packet 13, and Packet 14 fixes the runtime issue that kept Nostr broadcasting disabled under Python 3.13.

## Scope

### Included

* Uses `NOSTR_PRIVATE_KEY` when configured
* Preserves ephemeral identity fallback when no key is set
* Adds startup logging for persistent vs ephemeral identity mode
* Documents Nostr key configuration in `.env.example`
* Removes broken `RelayManager` usage
* Replaces relay publishing with lightweight `aiohttp` WebSocket publishing
* Keeps optional Nostr fallback behavior
* Adds focused tests for persistent, ephemeral, malformed, unavailable, and WebSocket publishing paths

### Not Included

* Nostr subscription/query discovery
* Relay retry/backoff strategy
* Reputation system
* Agent registry
* Payment changes
* Identity crypto redesign

## Validation

### Tests Run

```bash
PYTHONPATH=. pytest tests/agents/ tests/integration/ tests/security/ -q
```

### Results

* [x] Passing
* 72 passed
* 0 failed
* 0 skipped

## Known Limitations

* `_query_events` remains a stub returning `[]`
* Nostr relay publishing is best-effort and does not currently retry failed relays
* Discovery via Nostr subscription should be implemented in a follow-up packet

## Risk Level

* [x] Medium

## Rollback Plan

Revert:

* `7c7a14f`
* `bd43394`

## Packet / Branch Info

* Packet 13: Persistent Nostr identity
* Packet 14: Python 3.13 Nostr runtime support
* Branch: `packet-13`
* Commits:

  * `7c7a14f`
  * `bd43394`

## Checklist

* [x] One related feature area
* [x] No generated files committed
* [x] No unrelated payment changes
* [x] No unrelated identity crypto changes
* [x] Existing fallback behavior preserved
* [x] Tests documented
* [x] Ready for review