### PR TITLE
feat: implement Nostr query discovery

### DIFF
--- a/src/network/p2p_discovery.py
+++ b/src/network/p2p_discovery.py
@@ -43,6 +43,55 @@ async def _ws_publish(url: str, msg: str) -> None:
             await ws.send_str(msg)
             await asyncio.sleep(0.3)  # brief wait for relay ACK
 
+
+async def _ws_query(url: str, req_msg: str, sub_id: str, per_relay_timeout: float = 5.0) -> List[dict]:
+    """
+    Query a single Nostr relay and collect EVENT messages until EOSE or timeout.
+
+    Sends a NIP-01 REQ, accumulates EVENT payloads, stops on EOSE or timeout,
+    then sends CLOSE. Returns a list of raw event dicts. Best-effort: any
+    connection or protocol error returns an empty list.
+    """
+    events: List[dict] = []
+    connect_timeout = aiohttp.ClientTimeout(connect=5, total=per_relay_timeout + 5)
+    try:
+        async with aiohttp.ClientSession(timeout=connect_timeout) as session:
+            async with session.ws_connect(url, ssl=False, heartbeat=None) as ws:
+                await ws.send_str(req_msg)
+                deadline = asyncio.get_event_loop().time() + per_relay_timeout
+                while True:
+                    remaining = deadline - asyncio.get_event_loop().time()
+                    if remaining <= 0:
+                        break
+                    try:
+                        raw = await asyncio.wait_for(ws.receive_str(), timeout=remaining)
+                    except asyncio.TimeoutError:
+                        break
+                    try:
+                        msg = json.loads(raw)
+                    except json.JSONDecodeError:
+                        logger.debug("Nostr query: malformed message from %s: %.120s", url, raw)
+                        continue
+                    if not isinstance(msg, list) or len(msg) < 2:
+                        continue
+                    msg_type = msg[0]
+                    if msg_type == "EVENT" and len(msg) == 3 and msg[1] == sub_id:
+                        event_data = msg[2]
+                        if isinstance(event_data, dict):
+                            events.append(event_data)
+                    elif msg_type == "EOSE" and msg[1] == sub_id:
+                        break
+                    elif msg_type in ("NOTICE", "OK", "AUTH"):
+                        logger.debug("Nostr query: relay notice from %s: %s", url, msg)
+                close_msg = json.dumps(["CLOSE", sub_id])
+                try:
+                    await ws.send_str(close_msg)
+                except Exception:
+                    pass
+    except Exception as e:
+        logger.debug("Nostr query: relay %s unavailable: %s", url, e)
+    return events
+
 class DiscoveryProtocol(Enum):
     NOSTR = "nostr"
     DHT = "dht"
@@ -306,9 +355,48 @@ class EnhancedNostrDiscovery:
             logger.debug("Nostr: %d/%d relay(s) did not acknowledge event", failed, len(self.relays))
 
     async def _query_events(self, filters) -> List[Event]:
-        """Query events from relays (not yet implemented; returns empty list)."""
-        logger.debug("Nostr: relay query not implemented; returning empty")
-        return []
+        """
+        Query all configured relays for events matching `filters`.
+
+        Sends a NIP-01 REQ to each relay concurrently, collects EVENT messages
+        until EOSE or a per-relay timeout, then reconstructs Event objects from
+        the raw dicts. Relay failures are best-effort and logged at debug level.
+        """
+        sub_id = hashlib.sha256(str(time.time()).encode()).hexdigest()[:12]
+
+        # Build the REQ filter payload from the Filters object.
+        # Filters is a UserList; to_json_array() returns a list of filter dicts.
+        try:
+            filter_dicts = filters.to_json_array()
+        except Exception as e:
+            logger.warning("Nostr: could not serialise filters (%s); aborting query", e)
+            return []
+
+        req_msg = json.dumps(["REQ", sub_id] + filter_dicts)
+
+        tasks = [_ws_query(url, req_msg, sub_id) for url in self.relays]
+        per_relay_results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        events: List[Event] = []
+        for result in per_relay_results:
+            if isinstance(result, Exception):
+                continue
+            for raw in result:
+                try:
+                    event = Event(
+                        public_key=raw.get("pubkey", ""),
+                        content=raw.get("content", ""),
+                        created_at=raw.get("created_at", int(time.time())),
+                        kind=raw.get("kind", 30078),
+                        tags=raw.get("tags", []),
+                        signature=raw.get("sig", ""),
+                    )
+                    events.append(event)
+                except Exception as e:
+                    logger.debug("Nostr: skipping malformed event: %s", e)
+
+        logger.debug("Nostr: query returned %d event(s) across %d relay(s)", len(events), len(self.relays))
+        return events
 
 class P2PDiscoveryManager:
     """Main discovery manager coordinating multiple discovery protocols."""

--- a/tests/agents/test_nostr_identity.py
+++ b/tests/agents/test_nostr_identity.py
@@ -1,20 +1,22 @@
 """
-Tests for persistent vs ephemeral Nostr identity in EnhancedNostrDiscovery.
-Covers: valid persistent key, no-key ephemeral fallback, malformed key fallback,
-        unavailable-Nostr error path, and _ws_publish relay helper.
+Tests for persistent vs ephemeral Nostr identity in EnhancedNostrDiscovery,
+and for the relay query (_query_events / _ws_query) introduced in Packet 15.
 
 python-nostr's Event/PrivateKey/Filter modules import cleanly under Python 3.13.
 RelayManager was dropped (its relay.py uses a mutable dataclass default rejected
-by Python 3.13); relay connectivity is now handled by _ws_publish via aiohttp.
-NOSTR_AVAILABLE is therefore True at import time — no patching required for the
-happy-path tests.
+by Python 3.13); relay connectivity is now handled by _ws_publish/_ws_query via
+aiohttp. NOSTR_AVAILABLE is therefore True at import time — no patching required
+for the happy-path tests.
 """
 
 import asyncio
+import json
 import logging
+import time
 import pytest
 from unittest.mock import patch, AsyncMock, MagicMock
 from nostr.key import PrivateKey
+from nostr.filter import Filter, Filters
 
 import src.network.p2p_discovery as pd_module
 
@@ -134,3 +136,178 @@ class TestWsPublish:
             asyncio.run(pd_module._ws_publish("wss://relay.example.com", '["EVENT",{}]'))
 
         mock_ws.send_str.assert_awaited_once_with('["EVENT",{}]')
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by TestWsQuery and TestQueryEvents
+# ---------------------------------------------------------------------------
+
+def _raw_event(agent_id: str = "agent-1") -> dict:
+    return {
+        "pubkey": "aa" * 32,
+        "content": json.dumps({"agent_id": agent_id}),
+        "created_at": int(time.time()),
+        "kind": 30078,
+        "tags": [["t", "bitagent"]],
+        "sig": "cc" * 32,
+    }
+
+
+def _make_filters() -> Filters:
+    return Filters([Filter(kinds=[30078], since=int(time.time() - 3600))])
+
+
+# ---------------------------------------------------------------------------
+# _ws_query unit tests
+# ---------------------------------------------------------------------------
+
+class TestWsQuery:
+    """_ws_query collects EVENT messages and stops on EOSE or timeout."""
+
+    def _run(self, messages: list[str], url: str = "wss://relay.test") -> list[dict]:
+        """
+        Drive _ws_query against a fake WebSocket that yields `messages` in order.
+        Each call to receive_str() pops the next message from the list.
+        """
+        msg_iter = iter(messages)
+
+        async def fake_receive_str(timeout=None):
+            try:
+                return next(msg_iter)
+            except StopIteration:
+                raise asyncio.TimeoutError
+
+        mock_ws = AsyncMock()
+        mock_ws.receive_str = fake_receive_str
+        mock_ws.send_str = AsyncMock()
+        mock_ws.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_ws.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.ws_connect = MagicMock(return_value=mock_ws)
+
+        with patch("src.network.p2p_discovery.aiohttp.ClientSession", return_value=mock_session):
+            return asyncio.run(pd_module._ws_query(url, '["REQ","sub1",{}]', "sub1"))
+
+    def test_returns_events_before_eose(self):
+        evt = json.dumps(["EVENT", "sub1", _raw_event("a1")])
+        eose = json.dumps(["EOSE", "sub1"])
+        results = self._run([evt, eose])
+        assert len(results) == 1
+        assert results[0]["content"] == json.dumps({"agent_id": "a1"})
+
+    def test_multiple_events_before_eose(self):
+        msgs = [
+            json.dumps(["EVENT", "sub1", _raw_event("a1")]),
+            json.dumps(["EVENT", "sub1", _raw_event("a2")]),
+            json.dumps(["EOSE", "sub1"]),
+        ]
+        results = self._run(msgs)
+        assert len(results) == 2
+
+    def test_stops_at_eose_ignores_later_events(self):
+        msgs = [
+            json.dumps(["EVENT", "sub1", _raw_event("a1")]),
+            json.dumps(["EOSE", "sub1"]),
+            json.dumps(["EVENT", "sub1", _raw_event("a2")]),  # should not be collected
+        ]
+        results = self._run(msgs)
+        assert len(results) == 1
+
+    def test_timeout_returns_partial_results(self):
+        # Only one event before the iterator runs out (simulating timeout)
+        msgs = [json.dumps(["EVENT", "sub1", _raw_event("a1")])]
+        results = self._run(msgs)
+        assert len(results) == 1
+
+    def test_empty_result_when_no_events(self):
+        results = self._run([json.dumps(["EOSE", "sub1"])])
+        assert results == []
+
+    def test_malformed_json_skipped(self):
+        msgs = [
+            "not valid json{{",
+            json.dumps(["EVENT", "sub1", _raw_event("a1")]),
+            json.dumps(["EOSE", "sub1"]),
+        ]
+        results = self._run(msgs)
+        assert len(results) == 1
+
+    def test_event_for_wrong_sub_id_skipped(self):
+        msgs = [
+            json.dumps(["EVENT", "other-sub", _raw_event("a1")]),
+            json.dumps(["EOSE", "sub1"]),
+        ]
+        results = self._run(msgs)
+        assert results == []
+
+    def test_connection_failure_returns_empty(self):
+        with patch("src.network.p2p_discovery.aiohttp.ClientSession", side_effect=OSError("refused")):
+            result = asyncio.run(pd_module._ws_query("wss://dead.relay", '["REQ","s",{}]', "s"))
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _query_events integration tests
+# ---------------------------------------------------------------------------
+
+class TestQueryEvents:
+    """_query_events aggregates results from all relays via _ws_query."""
+
+    def test_returns_events_from_all_relays(self):
+        async def fake_query(url, req_msg, sub_id, per_relay_timeout=5.0):
+            return [_raw_event(url[-4:])]  # one unique event per relay
+
+        async def run():
+            d = pd_module.EnhancedNostrDiscovery()
+            with patch("src.network.p2p_discovery._ws_query", side_effect=fake_query):
+                return await d._query_events(_make_filters())
+
+        events = asyncio.run(run())
+        assert len(events) == len(pd_module.EnhancedNostrDiscovery().relays)
+
+    def test_relay_failure_does_not_crash(self):
+        call_count = 0
+
+        async def flaky_query(url, req_msg, sub_id, per_relay_timeout=5.0):
+            nonlocal call_count
+            call_count += 1
+            if call_count % 2 == 0:
+                raise OSError("dead relay")
+            return [_raw_event("ok")]
+
+        async def run():
+            d = pd_module.EnhancedNostrDiscovery()
+            with patch("src.network.p2p_discovery._ws_query", side_effect=flaky_query):
+                return await d._query_events(_make_filters())
+
+        events = asyncio.run(run())
+        assert len(events) > 0  # at least the non-failing relays contributed
+
+    def test_all_relays_fail_returns_empty(self):
+        async def dead_query(url, req_msg, sub_id, per_relay_timeout=5.0):
+            return []
+
+        async def run():
+            d = pd_module.EnhancedNostrDiscovery()
+            with patch("src.network.p2p_discovery._ws_query", side_effect=dead_query):
+                return await d._query_events(_make_filters())
+
+        events = asyncio.run(run())
+        assert events == []
+
+    def test_malformed_event_dict_skipped(self):
+        """A raw event with bad fields should be dropped, not crash the method."""
+        async def bad_query(url, req_msg, sub_id, per_relay_timeout=5.0):
+            return [{"this": "is", "not": "a valid event"}]
+
+        async def run():
+            d = pd_module.EnhancedNostrDiscovery()
+            with patch("src.network.p2p_discovery._ws_query", side_effect=bad_query):
+                return await d._query_events(_make_filters())
+
+        # Should not raise; bad events are silently dropped
+        events = asyncio.run(run())
+        assert isinstance(events, list)


### PR DESCRIPTION
## What This PR Changes
Implements Nostr relay query discovery using lightweight aiohttp WebSocket support.

## Why This Matters
Packets 13–14 made BitAgent identity persistent and restored relay publishing. This packet enables discovery from relays so BitAgent can find other announced agents.

## Scope
### Included
- Minimal Nostr REQ query flow
- EVENT collection until EOSE or timeout
- Best-effort relay failure handling
- Mocked tests for success and failure cases

### Not Included
- Full relay subscription manager
- Retry/backoff strategy
- Reputation scoring
- Agent registry
- Payment changes

## Validation
```
PYTHONPATH=. pytest tests/agents/ tests/integration/ tests/security/ -q
```
84 passed, 0 failed, 0 skipped (72 baseline + 12 new)

## Known Limitations
- `_query_events` currently returns raw Event objects with content as-is; `discover_agents` still parses `event.content` as JSON, so end-to-end agent discovery works when relays return well-formed BitAgent announcements
- No retry or backoff on relay failure — best-effort only
- Relay subscription (live streaming) not implemented; query is one-shot REQ/EOSE

## Rollback Plan
Revert commit `8287761`.