### PR TITLE
docs: add standalone BitAgent static site

### DIFF
--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -1,0 +1,24 @@
+# BitAgent Static Site
+
+Standalone HTML documentation for the BitAgent framework.
+
+## Pages
+
+| File | Description |
+|---|---|
+| `index.html` | Overview and quick-start |
+| `agents.html` | Agent catalogue and pricing |
+| `architecture.html` | System architecture and request lifecycle |
+| `payments.html` | Lightning and Fedimint payment flows |
+| `discovery.html` | Nostr-based agent discovery |
+| `api.html` | REST and A2A API reference |
+
+## Usage
+
+No build step required. Open any file directly in a browser:
+
+```
+open docs/site/index.html
+```
+
+All pages are self-contained — no server, no bundler, no dependencies.

--- a/docs/site/agents.html
+++ b/docs/site/agents.html
@@ -1,0 +1,386 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Agents — BitAgent</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #0d1117; --surface: #161b22; --border: #30363d;
+      --orange: #f7931a; --text: #e6edf3; --muted: #8b949e;
+      --green: #3fb950; --blue: #58a6ff; --purple: #a371f7;
+      --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      --mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    }
+    body { background: var(--bg); color: var(--text); font-family: var(--font); line-height: 1.6; }
+    nav {
+      background: var(--surface); border-bottom: 1px solid var(--border);
+      padding: 0 2rem; display: flex; align-items: center; gap: 2rem;
+      height: 56px; position: sticky; top: 0; z-index: 100;
+    }
+    nav .logo { font-weight: 700; font-size: 1.1rem; color: var(--orange); text-decoration: none; }
+    nav a { color: var(--muted); text-decoration: none; font-size: 0.9rem; transition: color 0.15s; }
+    nav a:hover, nav a.active { color: var(--text); }
+    nav .spacer { flex: 1; }
+    nav .badge { background: var(--orange); color: #000; font-size: 0.7rem; font-weight: 700; padding: 2px 8px; border-radius: 99px; text-decoration: none; }
+
+    .page-header { max-width: 860px; margin: 3rem auto 0; padding: 0 2rem 2rem; border-bottom: 1px solid var(--border); }
+    .page-header h1 { font-size: 2rem; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 0.4rem; }
+    .page-header p { color: var(--muted); }
+
+    .content { max-width: 860px; margin: 0 auto; padding: 3rem 2rem; }
+
+    .agent-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 2rem;
+      margin-bottom: 2rem;
+      scroll-margin-top: 72px;
+    }
+    .agent-card:hover { border-color: #444d56; }
+    .agent-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; margin-bottom: 1.25rem; flex-wrap: wrap; }
+    .agent-header h2 { font-size: 1.25rem; font-weight: 700; }
+    .agent-header .meta { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+    .tag {
+      font-size: 0.72rem; font-weight: 600; padding: 2px 10px; border-radius: 99px; border: 1px solid;
+    }
+    .tag-price { border-color: var(--orange); color: var(--orange); background: rgba(247,147,26,0.08); }
+    .tag-path { border-color: var(--border); color: var(--muted); background: transparent; font-family: var(--mono); }
+    .tag-status { border-color: var(--green); color: var(--green); background: rgba(63,185,80,0.08); }
+    .tag-a2a { border-color: var(--purple); color: var(--purple); background: rgba(163,113,247,0.08); }
+
+    .agent-desc { color: var(--muted); font-size: 0.9rem; margin-bottom: 1.25rem; }
+
+    .detail-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1.25rem; }
+    @media (max-width: 560px) { .detail-grid { grid-template-columns: 1fr; } }
+    .detail-block h4 { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.8px; color: var(--muted); margin-bottom: 0.4rem; }
+    .detail-block ul { list-style: none; }
+    .detail-block li { font-size: 0.85rem; padding: 2px 0; }
+    .detail-block li::before { content: "· "; color: var(--orange); }
+
+    pre {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 1rem 1.25rem;
+      overflow-x: auto;
+      font-family: var(--mono);
+      font-size: 0.78rem;
+      line-height: 1.65;
+    }
+    .comment { color: var(--muted); }
+    .key { color: var(--blue); }
+    .val { color: var(--green); }
+    .str { color: #a5d6ff; }
+    code { font-family: var(--mono); font-size: 0.84em; color: var(--orange); background: rgba(247,147,26,0.1); padding: 1px 5px; border-radius: 3px; }
+
+    footer { border-top: 1px solid var(--border); padding: 2rem; text-align: center; color: var(--muted); font-size: 0.8rem; }
+    footer a { color: var(--muted); text-decoration: none; }
+    footer a:hover { color: var(--text); }
+  </style>
+</head>
+<body>
+
+<nav>
+  <a class="logo" href="index.html">⚡ BitAgent</a>
+  <a href="index.html">Overview</a>
+  <a href="agents.html" class="active">Agents</a>
+  <a href="architecture.html">Architecture</a>
+  <a href="payments.html">Payments</a>
+  <a href="discovery.html">Discovery</a>
+  <a href="api.html">API</a>
+  <span class="spacer"></span>
+  <a class="badge" href="https://bitagent-production.up.railway.app/docs" target="_blank">Live Docs ↗</a>
+</nav>
+
+<div class="page-header">
+  <h1>Agents</h1>
+  <p>Seven live agents, each autonomous, each accepting Lightning or ecash payments.</p>
+</div>
+
+<div class="content">
+
+  <!-- POLYGLOT -->
+  <div class="agent-card" id="polyglot">
+    <div class="agent-header">
+      <h2>🌐 PolyglotAgent</h2>
+      <div class="meta">
+        <span class="tag tag-status">● live</span>
+        <span class="tag tag-price">100–250 sats</span>
+        <span class="tag tag-path">/polyglot</span>
+      </div>
+    </div>
+    <p class="agent-desc">Translates text between languages and transcribes audio files using OpenAI Whisper. The cheapest and most-used agent in the stack — translation drives the coordinator and MCP tool integrations.</p>
+    <div class="detail-grid">
+      <div class="detail-block">
+        <h4>Services</h4>
+        <ul>
+          <li>translate — 100 sats/request</li>
+          <li>transcribe — 250 sats/request (Whisper, local-only)</li>
+        </ul>
+      </div>
+      <div class="detail-block">
+        <h4>Notes</h4>
+        <ul>
+          <li>Whisper excluded from prod build (avoids PyTorch ~2 GB pull)</li>
+          <li>Translation is live in production</li>
+          <li>Accepts Lightning and Fedimint ecash</li>
+        </ul>
+      </div>
+    </div>
+    <pre><span class="comment"># Translate English → Spanish</span>
+curl -X POST https://bitagent-production.up.railway.app/polyglot/translate \
+  -H "Content-Type: application/json" \
+  -d '{
+    <span class="key">"text"</span>: <span class="str">"Hello, world"</span>,
+    <span class="key">"source_lang"</span>: <span class="str">"en"</span>,
+    <span class="key">"target_lang"</span>: <span class="str">"es"</span>,
+    <span class="key">"payment_hash"</span>: <span class="str">"&lt;paid_hash&gt;"</span>
+  }'</pre>
+  </div>
+
+  <!-- COORDINATOR -->
+  <div class="agent-card" id="coordinator">
+    <div class="agent-header">
+      <h2>🎯 CoordinatorAgent</h2>
+      <div class="meta">
+        <span class="tag tag-status">● live</span>
+        <span class="tag tag-price">350 sats</span>
+        <span class="tag tag-path">/coordinator</span>
+      </div>
+    </div>
+    <p class="agent-desc">Orchestrates multi-step workflows by chaining calls to specialist agents. Accepts a high-level task and returns a combined result — the client pays once; the coordinator handles all downstream agent calls.</p>
+    <div class="detail-grid">
+      <div class="detail-block">
+        <h4>Capabilities</h4>
+        <ul>
+          <li>Sequential agent chaining</li>
+          <li>Result aggregation</li>
+          <li>Internal retry on agent failure</li>
+        </ul>
+      </div>
+      <div class="detail-block">
+        <h4>Typical workflow</h4>
+        <ul>
+          <li>Search → summarise → translate</li>
+          <li>Fetch page → extract → translate</li>
+          <li>Price → convert → format</li>
+        </ul>
+      </div>
+    </div>
+    <pre><span class="comment"># Chain: search + translate in one call</span>
+POST /coordinator/coordinate
+{
+  <span class="key">"task"</span>: <span class="str">"search for bitcoin news and translate to German"</span>,
+  <span class="key">"payment_hash"</span>: <span class="str">"&lt;paid_hash&gt;"</span>
+}</pre>
+  </div>
+
+  <!-- ORACLE -->
+  <div class="agent-card" id="oracle">
+    <div class="agent-header">
+      <h2>📈 PriceOracleAgent</h2>
+      <div class="meta">
+        <span class="tag tag-status">● live</span>
+        <span class="tag tag-price">2 sats</span>
+        <span class="tag tag-path">/oracle</span>
+        <span class="tag tag-a2a">A2A: oracle.*</span>
+      </div>
+    </div>
+    <p class="agent-desc">Returns real-time crypto prices at 2 sats per request — the cheapest paid agent in the stack. CoinGecko is the primary source with Binance as a fallback. Results are cached for 60 seconds to avoid hammering upstream APIs.</p>
+    <div class="detail-grid">
+      <div class="detail-block">
+        <h4>A2A methods</h4>
+        <ul>
+          <li>oracle.price — single asset</li>
+          <li>oracle.prices — multiple assets</li>
+          <li>oracle.convert — cross-asset conversion</li>
+        </ul>
+      </div>
+      <div class="detail-block">
+        <h4>Sources</h4>
+        <ul>
+          <li>Primary: CoinGecko</li>
+          <li>Fallback: Binance ticker</li>
+          <li>Cache TTL: 60 seconds</li>
+        </ul>
+      </div>
+    </div>
+    <pre><span class="comment"># Get BTC price in USD</span>
+POST /a2a
+{
+  <span class="key">"method"</span>: <span class="str">"oracle.price"</span>,
+  <span class="key">"params"</span>: { <span class="key">"asset"</span>: <span class="str">"bitcoin"</span>, <span class="key">"currency"</span>: <span class="str">"usd"</span> }
+}</pre>
+  </div>
+
+  <!-- FETCH -->
+  <div class="agent-card" id="fetch">
+    <div class="agent-header">
+      <h2>🌍 WebFetchAgent</h2>
+      <div class="meta">
+        <span class="tag tag-status">● live</span>
+        <span class="tag tag-price">25 sats</span>
+        <span class="tag tag-path">/fetch</span>
+        <span class="tag tag-a2a">A2A: fetch.url</span>
+      </div>
+    </div>
+    <p class="agent-desc">Fetches web pages and returns their content. Includes SSRF protection that blocks requests to private IP ranges (RFC 1918, loopback, link-local) to prevent internal network access.</p>
+    <div class="detail-grid">
+      <div class="detail-block">
+        <h4>Security</h4>
+        <ul>
+          <li>Blocks 10.x.x.x, 172.16–31.x.x, 192.168.x.x</li>
+          <li>Blocks 127.x.x.x and ::1</li>
+          <li>Blocks 169.254.x.x (link-local)</li>
+        </ul>
+      </div>
+      <div class="detail-block">
+        <h4>A2A method</h4>
+        <ul>
+          <li>fetch.url — returns page text/html</li>
+          <li>Configurable timeout</li>
+          <li>User-agent spoofing supported</li>
+        </ul>
+      </div>
+    </div>
+    <pre><span class="comment"># Fetch a URL</span>
+POST /a2a
+{
+  <span class="key">"method"</span>: <span class="str">"fetch.url"</span>,
+  <span class="key">"params"</span>: { <span class="key">"url"</span>: <span class="str">"https://example.com"</span> }
+}</pre>
+  </div>
+
+  <!-- SEARCH -->
+  <div class="agent-card" id="search">
+    <div class="agent-header">
+      <h2>🔎 SearchAgent</h2>
+      <div class="meta">
+        <span class="tag tag-status">● live</span>
+        <span class="tag tag-price">10 sats</span>
+        <span class="tag tag-path">/search</span>
+        <span class="tag tag-a2a">A2A: search.query</span>
+      </div>
+    </div>
+    <p class="agent-desc">Runs web searches with a three-tier fallback chain. Brave Search is tried first (fastest, privacy-respecting), then SearXNG (self-hosted meta-search), then DuckDuckGo via <code>ddgs</code> as a last resort.</p>
+    <div class="detail-grid">
+      <div class="detail-block">
+        <h4>Fallback chain</h4>
+        <ul>
+          <li>1. Brave Search API</li>
+          <li>2. SearXNG instance</li>
+          <li>3. DuckDuckGo (ddgs library)</li>
+        </ul>
+      </div>
+      <div class="detail-block">
+        <h4>MCP tool</h4>
+        <ul>
+          <li>Exposed as Claude tool via MCP server</li>
+          <li>No HTTP — direct module import</li>
+          <li>Cost reported per call in sats</li>
+        </ul>
+      </div>
+    </div>
+    <pre><span class="comment"># Search the web</span>
+POST /a2a
+{
+  <span class="key">"method"</span>: <span class="str">"search.query"</span>,
+  <span class="key">"params"</span>: { <span class="key">"query"</span>: <span class="str">"lightning network capacity 2025"</span> }
+}</pre>
+  </div>
+
+  <!-- STREAMFINDER -->
+  <div class="agent-card" id="streamfinder">
+    <div class="agent-header">
+      <h2>📡 StreamfinderAgent</h2>
+      <div class="meta">
+        <span class="tag tag-status">● live</span>
+        <span class="tag tag-price">100 sats</span>
+        <span class="tag tag-a2a">A2A only</span>
+      </div>
+    </div>
+    <p class="agent-desc">The reference implementation of the Agent-to-Agent JSON-RPC pattern. Provides a <code>streamfinder.search</code> method that can be optionally gated behind NIP-05 identity verification and trust scoring.</p>
+    <div class="detail-grid">
+      <div class="detail-block">
+        <h4>A2A method</h4>
+        <ul>
+          <li>streamfinder.search — query stream DB</li>
+          <li>Optional identity trust gate</li>
+          <li>Requires requester_pubkey when gate active</li>
+        </ul>
+      </div>
+      <div class="detail-block">
+        <h4>Identity gate (opt-in)</h4>
+        <ul>
+          <li>IDENTITY_REQUIRE_FOR_PAID_SERVICES=true</li>
+          <li>IDENTITY_MIN_TRUST_SCORE=0.25 (default)</li>
+          <li>IDENTITY_FREE_QUERIES=false</li>
+        </ul>
+      </div>
+    </div>
+    <pre><span class="comment"># Search with identity gate enabled</span>
+POST /a2a
+{
+  <span class="key">"method"</span>: <span class="str">"streamfinder.search"</span>,
+  <span class="key">"params"</span>: {
+    <span class="key">"query"</span>: <span class="str">"bitcoin price feed"</span>,
+    <span class="key">"requester_pubkey"</span>: <span class="str">"&lt;nostr_pubkey_hex&gt;"</span>
+  }
+}</pre>
+  </div>
+
+  <!-- IDENTITY -->
+  <div class="agent-card" id="identity">
+    <div class="agent-header">
+      <h2>🪪 IdentityAgent</h2>
+      <div class="meta">
+        <span class="tag tag-status">● live</span>
+        <span class="tag tag-price">10–1000 sats</span>
+        <span class="tag tag-a2a">A2A only</span>
+      </div>
+    </div>
+    <p class="agent-desc">Handles NIP-05 identity registration (<code>name@domain</code> → Nostr pubkey mapping) and maintains a trust score for each registered pubkey. Backing store is SQLite. Exposes the <code>/.well-known/nostr.json</code> endpoint required by the NIP-05 spec.</p>
+    <div class="detail-grid">
+      <div class="detail-block">
+        <h4>A2A methods</h4>
+        <ul>
+          <li>identity.register_nip05</li>
+          <li>identity.get_identity</li>
+          <li>identity.list_verified</li>
+          <li>identity.search</li>
+          <li>identity.get_trust_signal</li>
+        </ul>
+      </div>
+      <div class="detail-block">
+        <h4>Trust scoring</h4>
+        <ul>
+          <li>Score range: 0.0 – 1.0</li>
+          <li>Factors: payment history, age, activity</li>
+          <li>Used as gate for streamfinder.search</li>
+          <li>Deterministic (same pubkey → same signal)</li>
+        </ul>
+      </div>
+    </div>
+    <pre><span class="comment"># Register a NIP-05 handle</span>
+POST /a2a
+{
+  <span class="key">"method"</span>: <span class="str">"identity.register_nip05"</span>,
+  <span class="key">"params"</span>: {
+    <span class="key">"handle"</span>: <span class="str">"alice"</span>,
+    <span class="key">"domain"</span>: <span class="str">"bitagent-production.up.railway.app"</span>,
+    <span class="key">"pubkey"</span>: <span class="str">"&lt;nostr_pubkey_hex&gt;"</span>
+  }
+}</pre>
+  </div>
+
+</div><!-- /content -->
+
+<footer>
+  <p>BitAgent · <a href="https://github.com/intrinsicinvestment91/bitagent" target="_blank">GitHub</a> · <a href="https://bitagent-production.up.railway.app/docs" target="_blank">Live API</a> · MIT License</p>
+</footer>
+
+</body>
+</html>

--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -1,0 +1,372 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>API Reference — BitAgent</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #0d1117; --surface: #161b22; --border: #30363d;
+      --orange: #f7931a; --text: #e6edf3; --muted: #8b949e;
+      --green: #3fb950; --blue: #58a6ff; --purple: #a371f7; --red: #f85149;
+      --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      --mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    }
+    body { background: var(--bg); color: var(--text); font-family: var(--font); line-height: 1.6; }
+    nav {
+      background: var(--surface); border-bottom: 1px solid var(--border);
+      padding: 0 2rem; display: flex; align-items: center; gap: 2rem;
+      height: 56px; position: sticky; top: 0; z-index: 100;
+    }
+    nav .logo { font-weight: 700; font-size: 1.1rem; color: var(--orange); text-decoration: none; }
+    nav a { color: var(--muted); text-decoration: none; font-size: 0.9rem; }
+    nav a:hover, nav a.active { color: var(--text); }
+    nav .spacer { flex: 1; }
+    nav .badge { background: var(--orange); color: #000; font-size: 0.7rem; font-weight: 700; padding: 2px 8px; border-radius: 99px; text-decoration: none; }
+
+    .layout { display: grid; grid-template-columns: 220px 1fr; min-height: calc(100vh - 56px); }
+    @media (max-width: 700px) { .layout { grid-template-columns: 1fr; } }
+
+    .sidebar {
+      background: var(--surface); border-right: 1px solid var(--border);
+      padding: 2rem 0; position: sticky; top: 56px; height: calc(100vh - 56px); overflow-y: auto;
+    }
+    .sidebar-section { padding: 0 1.25rem; margin-bottom: 1.5rem; }
+    .sidebar-section .label { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.8px; color: var(--muted); margin-bottom: 0.5rem; }
+    .sidebar-section a {
+      display: block; font-size: 0.82rem; color: var(--muted);
+      text-decoration: none; padding: 3px 0; transition: color 0.15s;
+    }
+    .sidebar-section a:hover { color: var(--text); }
+
+    .main { padding: 3rem 2.5rem; max-width: 760px; }
+
+    h1 { font-size: 1.8rem; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 0.4rem; }
+    h2 { font-size: 1.25rem; font-weight: 700; letter-spacing: -0.3px; margin: 2.5rem 0 0.5rem; scroll-margin-top: 72px; }
+    h3 { font-size: 1rem; font-weight: 600; margin: 1.5rem 0 0.4rem; }
+    p { color: var(--muted); font-size: 0.9rem; margin-bottom: 0.75rem; }
+    p strong { color: var(--text); }
+
+    .endpoint {
+      display: flex; align-items: center; gap: 0.75rem;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 6px; padding: 0.7rem 1rem; margin-bottom: 0.75rem;
+      scroll-margin-top: 72px;
+    }
+    .method {
+      font-family: var(--mono); font-size: 0.72rem; font-weight: 700;
+      padding: 2px 8px; border-radius: 4px; white-space: nowrap;
+    }
+    .method.get { background: rgba(63,185,80,0.15); color: var(--green); }
+    .method.post { background: rgba(88,166,255,0.15); color: var(--blue); }
+    .path { font-family: var(--mono); font-size: 0.85rem; color: var(--text); flex: 1; }
+    .endpoint-note { font-size: 0.78rem; color: var(--muted); }
+
+    pre {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 8px; padding: 1rem 1.25rem; overflow-x: auto;
+      font-family: var(--mono); font-size: 0.78rem; line-height: 1.65; margin: 0.75rem 0 1.25rem;
+    }
+    code { font-family: var(--mono); font-size: 0.84em; color: var(--orange); background: rgba(247,147,26,0.1); padding: 1px 5px; border-radius: 3px; }
+
+    table { width: 100%; border-collapse: collapse; font-size: 0.83rem; margin: 0.75rem 0 1.25rem; }
+    th { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 2px solid var(--border); color: var(--muted); font-weight: 600; font-size: 0.7rem; text-transform: uppercase; }
+    td { padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+    tr:last-child td { border-bottom: none; }
+    td:first-child { font-family: var(--mono); font-size: 0.78rem; color: var(--orange); }
+    td.req { color: var(--red); font-size: 0.75rem; }
+    td.opt { color: var(--muted); font-size: 0.75rem; }
+
+    .status { font-family: var(--mono); font-size: 0.8rem; padding: 2px 8px; border-radius: 4px; font-weight: 600; }
+    .s200 { background: rgba(63,185,80,0.12); color: var(--green); }
+    .s402 { background: rgba(247,147,26,0.12); color: var(--orange); }
+    .s404 { background: rgba(248,81,73,0.12); color: var(--red); }
+    .s422 { background: rgba(248,81,73,0.12); color: var(--red); }
+
+    footer { border-top: 1px solid var(--border); padding: 2rem; text-align: center; color: var(--muted); font-size: 0.8rem; }
+    footer a { color: var(--muted); text-decoration: none; }
+  </style>
+</head>
+<body>
+
+<nav>
+  <a class="logo" href="index.html">⚡ BitAgent</a>
+  <a href="index.html">Overview</a>
+  <a href="agents.html">Agents</a>
+  <a href="architecture.html">Architecture</a>
+  <a href="payments.html">Payments</a>
+  <a href="discovery.html">Discovery</a>
+  <a href="api.html" class="active">API</a>
+  <span class="spacer"></span>
+  <a class="badge" href="https://bitagent-production.up.railway.app/docs" target="_blank">Live Docs ↗</a>
+</nav>
+
+<div class="layout">
+  <nav class="sidebar">
+    <div class="sidebar-section">
+      <div class="label">General</div>
+      <a href="#base">Base URL</a>
+      <a href="#payment">Payment pattern</a>
+      <a href="#health">Health</a>
+    </div>
+    <div class="sidebar-section">
+      <div class="label">Agents</div>
+      <a href="#polyglot">Polyglot</a>
+      <a href="#oracle">Oracle</a>
+      <a href="#search">Search</a>
+      <a href="#fetch">WebFetch</a>
+    </div>
+    <div class="sidebar-section">
+      <div class="label">A2A JSON-RPC</div>
+      <a href="#a2a">POST /a2a</a>
+      <a href="#a2a-oracle">oracle.*</a>
+      <a href="#a2a-search">search.*</a>
+      <a href="#a2a-fetch">fetch.*</a>
+      <a href="#a2a-identity">identity.*</a>
+      <a href="#a2a-streamfinder">streamfinder.*</a>
+    </div>
+    <div class="sidebar-section">
+      <div class="label">Registry</div>
+      <a href="#registry">GET /agents/registry</a>
+      <a href="#registry-id">GET /agents/registry/{id}</a>
+    </div>
+    <div class="sidebar-section">
+      <div class="label">System</div>
+      <a href="#status">Agent status</a>
+      <a href="#wallet">Wallet balance</a>
+      <a href="#nip05">NIP-05</a>
+    </div>
+  </nav>
+
+  <div class="main">
+    <h1>API Reference</h1>
+    <p>All endpoints below are live at the production deployment.</p>
+
+    <!-- BASE URL -->
+    <h2 id="base">Base URL</h2>
+    <pre>https://bitagent-production.up.railway.app</pre>
+    <p>Interactive Swagger UI: <code>/docs</code> &nbsp; ReDoc: <code>/redoc</code></p>
+
+    <!-- PAYMENT PATTERN -->
+    <h2 id="payment">Payment pattern</h2>
+    <p>All paid endpoints follow the same 402 → pay → resubmit flow. If <code>payment_hash</code> is absent, the response is HTTP 402 with an invoice.</p>
+    <table>
+      <thead><tr><th>Field</th><th>Direction</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td>payment_hash</td><td>Request</td><td>SHA-256 of the paid invoice preimage (hex)</td></tr>
+        <tr><td>ecash_notes</td><td>Request</td><td>Fedimint ecash notes string (alternative to payment_hash)</td></tr>
+        <tr><td>invoice</td><td>402 Response</td><td>bolt11 Lightning invoice</td></tr>
+        <tr><td>amount_sats</td><td>402 Response</td><td>Amount required in satoshis</td></tr>
+        <tr><td>cost_sats</td><td>200 Response</td><td>Amount deducted (echoed back to client)</td></tr>
+      </tbody>
+    </table>
+
+    <!-- HEALTH -->
+    <h2 id="health">Health check</h2>
+    <div class="endpoint">
+      <span class="method get">GET</span>
+      <span class="path">/health</span>
+      <span class="endpoint-note">No auth, no payment</span>
+    </div>
+    <pre>{ "status": "healthy", "version": "1.0.0" }</pre>
+
+    <!-- POLYGLOT -->
+    <h2 id="polyglot">Polyglot — /polyglot</h2>
+    <div class="endpoint">
+      <span class="method post">POST</span>
+      <span class="path">/polyglot/translate</span>
+      <span class="endpoint-note">100 sats</span>
+    </div>
+    <table>
+      <thead><tr><th>Field</th><th></th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td>text</td><td class="req">required</td><td>Text to translate (max 5000 chars)</td></tr>
+        <tr><td>source_lang</td><td class="req">required</td><td>BCP-47 language code (e.g. "en")</td></tr>
+        <tr><td>target_lang</td><td class="req">required</td><td>BCP-47 language code (e.g. "es")</td></tr>
+        <tr><td>payment_hash</td><td class="opt">optional</td><td>Omit to receive invoice</td></tr>
+      </tbody>
+    </table>
+    <pre><span style="color:#8b949e"># Request</span>
+{
+  "text": "Hello, world",
+  "source_lang": "en",
+  "target_lang": "es",
+  "payment_hash": "1b741d85..."
+}
+
+<span style="color:#8b949e"># 200 Response</span>
+{ "translated_text": "Hola, mundo", "cost_sats": 100 }</pre>
+
+    <!-- ORACLE -->
+    <h2 id="oracle">Price Oracle — /oracle</h2>
+    <div class="endpoint">
+      <span class="method get">GET</span>
+      <span class="path">/oracle/price/{asset}</span>
+      <span class="endpoint-note">2 sats</span>
+    </div>
+    <pre>GET /oracle/price/bitcoin?payment_hash=...
+
+{ "asset": "bitcoin", "price_usd": 95420.00, "cost_sats": 2 }</pre>
+
+    <!-- SEARCH -->
+    <h2 id="search">Search — /search</h2>
+    <div class="endpoint">
+      <span class="method post">POST</span>
+      <span class="path">/search/search</span>
+      <span class="endpoint-note">10 sats</span>
+    </div>
+    <table>
+      <thead><tr><th>Field</th><th></th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td>query</td><td class="req">required</td><td>Search query string</td></tr>
+        <tr><td>max_results</td><td class="opt">optional</td><td>Max results (default 10)</td></tr>
+        <tr><td>payment_hash</td><td class="opt">optional</td><td>Omit to receive invoice</td></tr>
+      </tbody>
+    </table>
+    <pre>{ "query": "bitcoin news", "payment_hash": "..." }
+
+{ "results": [{ "title": "...", "url": "...", "snippet": "..." }], "cost_sats": 10 }</pre>
+
+    <!-- FETCH -->
+    <h2 id="fetch">Web Fetch — /fetch</h2>
+    <div class="endpoint">
+      <span class="method post">POST</span>
+      <span class="path">/fetch/fetch</span>
+      <span class="endpoint-note">25 sats</span>
+    </div>
+    <pre>{ "url": "https://example.com", "payment_hash": "..." }
+
+{ "content": "&lt;html&gt;...&lt;/html&gt;", "cost_sats": 25 }</pre>
+
+    <!-- A2A -->
+    <h2 id="a2a">A2A JSON-RPC — POST /a2a</h2>
+    <p>All A2A methods share a single endpoint using JSON-RPC 2.0 envelope.</p>
+    <pre>{
+  "jsonrpc": "2.0",
+  "method": "&lt;method&gt;",
+  "params": { ... },
+  "id": 1
+}
+
+<span style="color:#8b949e"># Response</span>
+{ "jsonrpc": "2.0", "result": { ... }, "id": 1 }</pre>
+
+    <h3 id="a2a-oracle">oracle.*</h3>
+    <table>
+      <thead><tr><th>Method</th><th>Params</th><th>Returns</th></tr></thead>
+      <tbody>
+        <tr><td>oracle.price</td><td>asset, currency?</td><td>price_usd, timestamp</td></tr>
+        <tr><td>oracle.prices</td><td>assets[], currency?</td><td>prices{}</td></tr>
+        <tr><td>oracle.convert</td><td>amount, from_asset, to_asset</td><td>converted_amount</td></tr>
+      </tbody>
+    </table>
+
+    <h3 id="a2a-search">search.*</h3>
+    <table>
+      <thead><tr><th>Method</th><th>Params</th><th>Returns</th></tr></thead>
+      <tbody>
+        <tr><td>search.query</td><td>query, max_results?</td><td>results[]</td></tr>
+      </tbody>
+    </table>
+
+    <h3 id="a2a-fetch">fetch.*</h3>
+    <table>
+      <thead><tr><th>Method</th><th>Params</th><th>Returns</th></tr></thead>
+      <tbody>
+        <tr><td>fetch.url</td><td>url, timeout?</td><td>content, status_code</td></tr>
+      </tbody>
+    </table>
+
+    <h3 id="a2a-identity">identity.*</h3>
+    <table>
+      <thead><tr><th>Method</th><th>Params</th><th>Returns</th></tr></thead>
+      <tbody>
+        <tr><td>identity.register_nip05</td><td>handle, domain, pubkey, relays?</td><td>invoice or success</td></tr>
+        <tr><td>identity.get_identity</td><td>handle, domain</td><td>identity record</td></tr>
+        <tr><td>identity.list_verified</td><td>domain?</td><td>verified[]</td></tr>
+        <tr><td>identity.search</td><td>query</td><td>matches[]</td></tr>
+        <tr><td>identity.get_trust_signal</td><td>pubkey</td><td>trust_score, warning?</td></tr>
+      </tbody>
+    </table>
+
+    <h3 id="a2a-streamfinder">streamfinder.*</h3>
+    <table>
+      <thead><tr><th>Method</th><th>Params</th><th>Returns</th></tr></thead>
+      <tbody>
+        <tr><td>streamfinder.search</td><td>query, requester_pubkey?</td><td>streams[]</td></tr>
+      </tbody>
+    </table>
+
+    <!-- REGISTRY -->
+    <h2 id="registry">Agent Registry</h2>
+    <div class="endpoint">
+      <span class="method get">GET</span>
+      <span class="path">/agents/registry</span>
+      <span class="endpoint-note">No auth · Cache-Control: max-age=10</span>
+    </div>
+    <table>
+      <thead><tr><th>Query param</th><th>Default</th><th>Constraints</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td>service</td><td>—</td><td>1–64 chars, [a-zA-Z0-9._-]</td><td>Filter by service capability</td></tr>
+        <tr><td>limit</td><td>50</td><td>1–100</td><td>Page size</td></tr>
+        <tr><td>offset</td><td>0</td><td>≥0</td><td>Skip N agents</td></tr>
+      </tbody>
+    </table>
+    <pre>{
+  "agents": [{
+    "agent_id": "bitagent-search",
+    "name": "SearchAgent",
+    "description": "Web search (10 sats)",
+    "endpoint": "https://bitagent-production.up.railway.app/search",
+    "services": ["search.query"],
+    "public_key": "a1b2c3...",
+    "protocol": "lightning+nostr",
+    "last_seen": 1747440000.0,
+    "reputation_score": 0.0,
+    "capabilities": {}
+  }],
+  "count": 1,
+  "total": 7,
+  "offset": 0,
+  "limit": 50,
+  "source": "local"
+}</pre>
+
+    <div class="endpoint" id="registry-id">
+      <span class="method get">GET</span>
+      <span class="path">/agents/registry/{agent_id}</span>
+      <span class="endpoint-note">Returns AgentEntry or 404</span>
+    </div>
+
+    <!-- SYSTEM -->
+    <h2 id="status">Agent status</h2>
+    <div class="endpoint">
+      <span class="method get">GET</span>
+      <span class="path">/agents/status</span>
+    </div>
+    <pre>{ "polyglot": {"status":"running"}, "search": {"status":"running"}, ... }</pre>
+
+    <h2 id="wallet">Wallet balance</h2>
+    <div class="endpoint">
+      <span class="method get">GET</span>
+      <span class="path">/wallet/balance</span>
+    </div>
+    <pre>{ "balance_sats": 68234 }</pre>
+
+    <h2 id="nip05">NIP-05 well-known</h2>
+    <div class="endpoint">
+      <span class="method get">GET</span>
+      <span class="path">/.well-known/nostr.json?name=alice</span>
+    </div>
+    <pre>{ "names": { "alice": "npub_hex..." }, "relays": { "npub_hex...": ["wss://..."] } }</pre>
+
+  </div><!-- /main -->
+</div><!-- /layout -->
+
+<footer>
+  <p>BitAgent · <a href="https://github.com/intrinsicinvestment91/bitagent" target="_blank">GitHub</a> · <a href="https://bitagent-production.up.railway.app/docs" target="_blank">Live API</a> · MIT License</p>
+</footer>
+
+</body>
+</html>

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Architecture — BitAgent</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #0d1117; --surface: #161b22; --border: #30363d;
+      --orange: #f7931a; --text: #e6edf3; --muted: #8b949e;
+      --green: #3fb950; --blue: #58a6ff; --purple: #a371f7;
+      --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      --mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    }
+    body { background: var(--bg); color: var(--text); font-family: var(--font); line-height: 1.6; }
+    nav {
+      background: var(--surface); border-bottom: 1px solid var(--border);
+      padding: 0 2rem; display: flex; align-items: center; gap: 2rem;
+      height: 56px; position: sticky; top: 0; z-index: 100;
+    }
+    nav .logo { font-weight: 700; font-size: 1.1rem; color: var(--orange); text-decoration: none; }
+    nav a { color: var(--muted); text-decoration: none; font-size: 0.9rem; transition: color 0.15s; }
+    nav a:hover, nav a.active { color: var(--text); }
+    nav .spacer { flex: 1; }
+    nav .badge { background: var(--orange); color: #000; font-size: 0.7rem; font-weight: 700; padding: 2px 8px; border-radius: 99px; text-decoration: none; }
+
+    .page-header { max-width: 900px; margin: 3rem auto 0; padding: 0 2rem 2rem; border-bottom: 1px solid var(--border); }
+    .page-header h1 { font-size: 2rem; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 0.4rem; }
+    .page-header p { color: var(--muted); }
+
+    .content { max-width: 900px; margin: 0 auto; padding: 3rem 2rem; }
+    .content h2 { font-size: 1.35rem; font-weight: 700; letter-spacing: -0.3px; margin: 2.5rem 0 0.4rem; }
+    .content h2:first-child { margin-top: 0; }
+    .content p { color: var(--muted); font-size: 0.92rem; margin-bottom: 1rem; }
+    .content p strong { color: var(--text); }
+
+    /* ASCII diagram box */
+    .diagram {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1.5rem 2rem;
+      font-family: var(--mono);
+      font-size: 0.78rem;
+      line-height: 1.7;
+      overflow-x: auto;
+      margin: 1.25rem 0;
+      white-space: pre;
+      color: var(--text);
+    }
+    .diagram .hl { color: var(--orange); }
+    .diagram .dim { color: var(--muted); }
+    .diagram .grn { color: var(--green); }
+    .diagram .blu { color: var(--blue); }
+    .diagram .pur { color: var(--purple); }
+
+    pre {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 8px; padding: 1rem 1.25rem; overflow-x: auto;
+      font-family: var(--mono); font-size: 0.78rem; line-height: 1.65;
+      margin: 1rem 0;
+    }
+
+    .layer-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 1rem; margin: 1.25rem 0; }
+    .layer-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1.25rem; }
+    .layer-card .layer-name { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.8px; color: var(--orange); margin-bottom: 0.5rem; }
+    .layer-card h3 { font-size: 0.95rem; font-weight: 600; margin-bottom: 0.4rem; }
+    .layer-card p { font-size: 0.82rem; color: var(--muted); }
+    .layer-card ul { list-style: none; margin-top: 0.4rem; }
+    .layer-card li { font-size: 0.82rem; color: var(--muted); padding: 1px 0; }
+    .layer-card li::before { content: "→ "; color: var(--orange); }
+
+    code { font-family: var(--mono); font-size: 0.84em; color: var(--orange); background: rgba(247,147,26,0.1); padding: 1px 5px; border-radius: 3px; }
+
+    table { width: 100%; border-collapse: collapse; margin: 1rem 0; font-size: 0.85rem; }
+    th { text-align: left; padding: 0.6rem 1rem; border-bottom: 2px solid var(--border); color: var(--muted); font-weight: 600; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.6px; }
+    td { padding: 0.6rem 1rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+    tr:last-child td { border-bottom: none; }
+    td:first-child { font-family: var(--mono); font-size: 0.8rem; color: var(--blue); }
+
+    footer { border-top: 1px solid var(--border); padding: 2rem; text-align: center; color: var(--muted); font-size: 0.8rem; }
+    footer a { color: var(--muted); text-decoration: none; }
+    footer a:hover { color: var(--text); }
+  </style>
+</head>
+<body>
+
+<nav>
+  <a class="logo" href="index.html">⚡ BitAgent</a>
+  <a href="index.html">Overview</a>
+  <a href="agents.html">Agents</a>
+  <a href="architecture.html" class="active">Architecture</a>
+  <a href="payments.html">Payments</a>
+  <a href="discovery.html">Discovery</a>
+  <a href="api.html">API</a>
+  <span class="spacer"></span>
+  <a class="badge" href="https://bitagent-production.up.railway.app/docs" target="_blank">Live Docs ↗</a>
+</nav>
+
+<div class="page-header">
+  <h1>Architecture</h1>
+  <p>How BitAgent is structured — layers, entry points, and module responsibilities.</p>
+</div>
+
+<div class="content">
+
+  <h2>System overview</h2>
+  <p>BitAgent is a FastAPI application deployed on Railway. All agents share a single process, a single LNbits wallet client, and a single Nostr identity. Agents are FastAPI routers mounted under path prefixes.</p>
+
+  <div class="diagram">┌─────────────────────────────────────────────────────────────┐
+│                    <span class="hl">BitAgent Process</span>                         │
+│                                                             │
+│  ┌──────────┐  ┌───────────┐  ┌────────┐  ┌──────────┐   │
+│  │<span class="grn">Polyglot  </span>│  │<span class="grn">Coordinator</span>│  │<span class="grn">Oracle  </span>│  │<span class="grn">WebFetch  </span>│   │
+│  │<span class="grn">/polyglot </span>│  │<span class="grn">/coordinator│  │<span class="grn">/oracle </span>│  │<span class="grn">/fetch    </span>│   │
+│  └──────────┘  └───────────┘  └────────┘  └──────────┘   │
+│                                                             │
+│  ┌──────────┐  ┌───────────┐  ┌─────────────────────────┐ │
+│  │<span class="grn">Search    </span>│  │<span class="grn">Registry  </span>│  │  <span class="blu">POST /a2a</span>               │ │
+│  │<span class="grn">/search   </span>│  │<span class="grn">/agents   </span>│  │  streamfinder.*        │ │
+│  └──────────┘  └───────────┘  │  identity.*             │ │
+│                                │  oracle.* / fetch.*      │ │
+│                                │  search.*               │ │
+│                                └─────────────────────────┘ │
+│                                                             │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │              <span class="hl">Shared Infrastructure</span>                   │   │
+│  │  <span class="pur">AgentWallet</span> (LNbits)  <span class="pur">FedimintWallet</span>              │   │
+│  │  <span class="pur">P2PDiscoveryManager</span>  (DHT + Nostr)                 │   │
+│  │  <span class="pur">EnhancedNostrDiscovery</span> (identity + relay publish)  │   │
+│  └─────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+          │                              │
+   <span class="hl">LNbits</span> (Lightning payments)    <span class="blu">Nostr relays</span> (discovery)
+   <span class="hl">Fedimint</span> (ecash, optional)      <span class="blu">DHT peers</span> (agent registry)</div>
+
+  <h2>Layer breakdown</h2>
+  <div class="layer-grid">
+    <div class="layer-card">
+      <div class="layer-name">Entry Points</div>
+      <h3>main.py</h3>
+      <p>Railway / cloud deployment. Mounts all routers, handles CORS, runs Nostr broadcast on startup.</p>
+      <ul>
+        <li>mcp_server.py — MCP stdio for Claude</li>
+        <li>start9_server.py — preserved, do not modify</li>
+      </ul>
+    </div>
+    <div class="layer-card">
+      <div class="layer-name">Agents — src/agents/</div>
+      <h3>FastAPI routers</h3>
+      <p>Each agent is a self-contained package with its own payment logic. No shared decorator; each checks <code>payment_hash</code> inline.</p>
+      <ul>
+        <li>polyglot_agent/</li>
+        <li>coordinator_agent/</li>
+        <li>price_oracle_agent/</li>
+        <li>web_fetch_agent/</li>
+        <li>search_agent/</li>
+        <li>streamfinder/ (A2A only)</li>
+        <li>identity_agent/ (A2A only)</li>
+      </ul>
+    </div>
+    <div class="layer-card">
+      <div class="layer-name">Network — src/network/</div>
+      <h3>Discovery + Registry</h3>
+      <p>P2P discovery over DHT and Nostr. Agent registry endpoint exposes known agents over HTTP.</p>
+      <ul>
+        <li>p2p_discovery.py — DHTNode, EnhancedNostrDiscovery, P2PDiscoveryManager</li>
+        <li>registry_router.py — GET /agents/registry</li>
+        <li>nostr.py — Kind 30078 announcements</li>
+      </ul>
+    </div>
+    <div class="layer-card">
+      <div class="layer-name">Wallets</div>
+      <h3>Payment backends</h3>
+      <p>Two tiers: Lightning via LNbits, ecash via Fedimint. AgentWallet is lazy (raises on missing config). FedimintWallet is eager but harmless when unconfigured.</p>
+      <ul>
+        <li>agent_wallet.py — LNbits REST wrapper</li>
+        <li>src/wallets/fedimint_wallet.py — ecash client</li>
+        <li>lnbits_client.py — raw HTTP</li>
+      </ul>
+    </div>
+    <div class="layer-card">
+      <div class="layer-name">Security — src/security/</div>
+      <h3>Auth + Encryption</h3>
+      <p>JWT auth, API key hierarchy, AES-256-GCM / ChaCha20-Poly1305 encryption, input sanitisation, Pydantic models at boundaries.</p>
+      <ul>
+        <li>authentication.py</li>
+        <li>encryption.py</li>
+        <li>secure_endpoints.py</li>
+        <li>payment_security.py</li>
+        <li>secure_communication.py</li>
+      </ul>
+    </div>
+    <div class="layer-card">
+      <div class="layer-name">Identity — src/identity/</div>
+      <h3>DID + NIP-05</h3>
+      <p>DID document creation for four methods. NIP-05 registration and trust scoring backed by SQLite.</p>
+      <ul>
+        <li>enhanced_did.py — did:key/web/bitcoin/nostr</li>
+        <li>did.py — basic DID operations</li>
+        <li>identity_agent/store.py — SQLite</li>
+      </ul>
+    </div>
+  </div>
+
+  <h2>Entry points</h2>
+  <table>
+    <thead><tr><th>File</th><th>Purpose</th><th>When to use</th></tr></thead>
+    <tbody>
+      <tr><td>main.py</td><td>FastAPI app — Railway / cloud</td><td>Production deployment</td></tr>
+      <tr><td>mcp_server.py</td><td>MCP stdio server</td><td>Claude Code tool integration</td></tr>
+      <tr><td>start9_server.py</td><td>Start9 / StartOS deployment</td><td>Self-hosted node</td></tr>
+      <tr><td>agent_logic.py</td><td>A2A dispatcher (called by /a2a)</td><td>Internal — not run directly</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Wallet lazy-loading pattern</h2>
+  <p>All live agents follow this pattern so that <strong>missing credentials don't crash startup</strong> — payments are simply disabled in dev mode.</p>
+  <pre>from src.wallets.fedimint_wallet import FedimintWallet
+
+_fedimint = FedimintWallet()   # eager — safe, no required args
+_wallet = None                  # lazy — raises if LNBITS_* not set
+
+def _get_wallet():
+    global _wallet
+    if _wallet is None:
+        try:
+            from agent_wallet import AgentWallet
+            _wallet = AgentWallet()
+        except Exception:
+            pass
+    return _wallet</pre>
+
+  <h2>A2A routing — agent_logic.py</h2>
+  <p>The <code>POST /a2a</code> endpoint dispatches JSON-RPC method calls by prefix. Adding a new A2A-capable agent means registering its handler here.</p>
+  <table>
+    <thead><tr><th>Method prefix</th><th>Routed to</th></tr></thead>
+    <tbody>
+      <tr><td>oracle.*</td><td>PriceOracleAgent</td></tr>
+      <tr><td>fetch.*</td><td>WebFetchAgent</td></tr>
+      <tr><td>search.*</td><td>SearchAgent</td></tr>
+      <tr><td>identity.*</td><td>IdentityAgent</td></tr>
+      <tr><td>streamfinder.*</td><td>StreamfinderAgent</td></tr>
+    </tbody>
+  </table>
+
+  <h2>MCP server</h2>
+  <p>Claude can call BitAgent agents as tools via the MCP stdio server. No HTTP — agent modules are imported directly. No payment gate in MCP mode; cost is reported in the response but not enforced.</p>
+  <pre><span style="color:#8b949e"># .mcp.json (Claude Code config)</span>
+{
+  "mcpServers": {
+    "bitagent": {
+      "command": "python",
+      "args": ["mcp_server.py"]
+    }
+  }
+}</pre>
+  <p>Available MCP tools: <code>translate</code>, <code>search</code>, <code>fetch_url</code>, <code>get_price</code>, <code>convert_sats</code>. Each returns a <code>cost_sats</code> field.</p>
+
+  <h2>SDEN relationship</h2>
+  <p>SDEN (<em>Sensor Data Exchange Node</em>) is a companion protocol for IoT devices that sell signed sensor data via Lightning. A SDEN producer node <strong>is</strong> a BitAgent agent — it uses BitAgent's wallet, Nostr discovery, and DID identity. The repos are one system; <code>SensorAgent</code> should extend BitAgent's <code>Agent</code> base class.</p>
+
+</div>
+
+<footer>
+  <p>BitAgent · <a href="https://github.com/intrinsicinvestment91/bitagent" target="_blank">GitHub</a> · <a href="https://bitagent-production.up.railway.app/docs" target="_blank">Live API</a> · MIT License</p>
+</footer>
+
+</body>
+</html>

--- a/docs/site/discovery.html
+++ b/docs/site/discovery.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Discovery — BitAgent</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #0d1117; --surface: #161b22; --border: #30363d;
+      --orange: #f7931a; --text: #e6edf3; --muted: #8b949e;
+      --green: #3fb950; --blue: #58a6ff; --purple: #a371f7;
+      --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      --mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    }
+    body { background: var(--bg); color: var(--text); font-family: var(--font); line-height: 1.6; }
+    nav {
+      background: var(--surface); border-bottom: 1px solid var(--border);
+      padding: 0 2rem; display: flex; align-items: center; gap: 2rem;
+      height: 56px; position: sticky; top: 0; z-index: 100;
+    }
+    nav .logo { font-weight: 700; font-size: 1.1rem; color: var(--orange); text-decoration: none; }
+    nav a { color: var(--muted); text-decoration: none; font-size: 0.9rem; }
+    nav a:hover, nav a.active { color: var(--text); }
+    nav .spacer { flex: 1; }
+    nav .badge { background: var(--orange); color: #000; font-size: 0.7rem; font-weight: 700; padding: 2px 8px; border-radius: 99px; text-decoration: none; }
+
+    .page-header { max-width: 900px; margin: 3rem auto 0; padding: 0 2rem 2rem; border-bottom: 1px solid var(--border); }
+    .page-header h1 { font-size: 2rem; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 0.4rem; }
+    .page-header p { color: var(--muted); }
+
+    .content { max-width: 900px; margin: 0 auto; padding: 3rem 2rem; }
+    h2 { font-size: 1.35rem; font-weight: 700; letter-spacing: -0.3px; margin: 2.5rem 0 0.4rem; }
+    h2:first-child { margin-top: 0; }
+    p { color: var(--muted); font-size: 0.92rem; margin-bottom: 1rem; }
+    p strong { color: var(--text); }
+
+    .proto-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; margin: 1.5rem 0; }
+    @media (max-width: 600px) { .proto-grid { grid-template-columns: 1fr; } }
+    .proto-card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 1.75rem; }
+    .proto-card .badge {
+      display: inline-block; font-size: 0.7rem; font-weight: 700;
+      text-transform: uppercase; letter-spacing: 0.8px;
+      padding: 2px 10px; border-radius: 99px; margin-bottom: 1rem;
+    }
+    .proto-card.nostr .badge { background: rgba(163,113,247,0.15); color: var(--purple); border: 1px solid var(--purple); }
+    .proto-card.dht .badge { background: rgba(88,166,255,0.15); color: var(--blue); border: 1px solid var(--blue); }
+    .proto-card h3 { font-size: 1.05rem; font-weight: 700; margin-bottom: 0.4rem; }
+    .proto-card p { font-size: 0.85rem; }
+    .proto-card ul { list-style: none; margin-top: 0.75rem; }
+    .proto-card li { font-size: 0.83rem; color: var(--muted); padding: 2px 0; }
+    .proto-card li::before { content: "· "; color: var(--orange); }
+
+    pre {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 8px; padding: 1rem 1.25rem; overflow-x: auto;
+      font-family: var(--mono); font-size: 0.78rem; line-height: 1.65; margin: 1rem 0;
+    }
+    code { font-family: var(--mono); font-size: 0.84em; color: var(--orange); background: rgba(247,147,26,0.1); padding: 1px 5px; border-radius: 3px; }
+
+    .relay-list { display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 1rem 0; }
+    .relay-chip {
+      font-family: var(--mono); font-size: 0.78rem;
+      background: var(--surface); border: 1px solid var(--border);
+      padding: 4px 12px; border-radius: 99px; color: var(--muted);
+    }
+
+    .nip-flow {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 8px; padding: 1.5rem 2rem; font-family: var(--mono);
+      font-size: 0.8rem; line-height: 1.8; overflow-x: auto; margin: 1rem 0;
+    }
+    .nip-send { color: var(--blue); }
+    .nip-recv { color: var(--green); }
+    .nip-comment { color: var(--muted); }
+
+    .identity-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; margin: 1rem 0; }
+    .did-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1.25rem; }
+    .did-card .method { font-family: var(--mono); font-size: 0.8rem; color: var(--purple); margin-bottom: 0.4rem; }
+    .did-card p { font-size: 0.82rem; color: var(--muted); margin: 0; }
+
+    footer { border-top: 1px solid var(--border); padding: 2rem; text-align: center; color: var(--muted); font-size: 0.8rem; }
+    footer a { color: var(--muted); text-decoration: none; }
+  </style>
+</head>
+<body>
+
+<nav>
+  <a class="logo" href="index.html">⚡ BitAgent</a>
+  <a href="index.html">Overview</a>
+  <a href="agents.html">Agents</a>
+  <a href="architecture.html">Architecture</a>
+  <a href="payments.html">Payments</a>
+  <a href="discovery.html" class="active">Discovery</a>
+  <a href="api.html">API</a>
+  <span class="spacer"></span>
+  <a class="badge" href="https://bitagent-production.up.railway.app/docs" target="_blank">Live Docs ↗</a>
+</nav>
+
+<div class="page-header">
+  <h1>Discovery &amp; Identity</h1>
+  <p>How agents find each other — Nostr broadcasting, DHT, NIP-05, and DIDs.</p>
+</div>
+
+<div class="content">
+
+  <h2>Two discovery protocols</h2>
+  <p>Agents are discovered through two complementary protocols running concurrently. Both are best-effort; losing one doesn't break the other.</p>
+
+  <div class="proto-grid">
+    <div class="proto-card nostr">
+      <div class="badge">Nostr</div>
+      <h3>📡 Nostr Kind 30078</h3>
+      <p>On startup, each agent broadcasts a signed Nostr event to all configured relays. Any client subscribed to Kind 30078 with the <code>bitagent</code> tag can discover the agent without a central directory.</p>
+      <ul>
+        <li>Signed with secp256k1 (NIP-01)</li>
+        <li>Persistent or ephemeral keypair</li>
+        <li>5 relays, concurrent publish</li>
+        <li>NIP-05 identity for stable names</li>
+      </ul>
+    </div>
+    <div class="proto-card dht">
+      <div class="badge">DHT</div>
+      <h3>🌐 Distributed Hash Table</h3>
+      <p>A lightweight in-process DHT stores agent records keyed by SHA-256 of the agent ID. Peer nodes can replicate entries and query each other directly over HTTP.</p>
+      <ul>
+        <li>SHA-256 keyed registry</li>
+        <li>TTL-based expiry (default 3600s)</li>
+        <li>Peer replication via POST /dht/store</li>
+        <li>Fallback when Nostr unavailable</li>
+      </ul>
+    </div>
+  </div>
+
+  <h2>Nostr identity — persistent vs ephemeral</h2>
+  <p>Set <code>NOSTR_PRIVATE_KEY</code> to maintain a stable identity across restarts. Without it, a fresh keypair is generated each time — useful for dev but means the agent accumulates no Nostr history.</p>
+  <pre><span style="color:#8b949e"># Generate a persistent key</span>
+python -c "from nostr.key import PrivateKey; print(PrivateKey().raw_secret.hex())"
+
+<span style="color:#8b949e"># Set in .env</span>
+NOSTR_PRIVATE_KEY=64_char_lowercase_hex_secp256k1_key</pre>
+
+  <p>On startup the server logs which mode is active:</p>
+  <pre><span style="color:#3fb950">INFO</span>  Nostr: persistent identity loaded (pubkey a1b2c3d4...)
+<span style="color:#f7931a">INFO</span>  Nostr: NOSTR_PRIVATE_KEY not set — ephemeral identity active (pubkey 9f8e7d6c...)</pre>
+
+  <p>If the key is present but malformed (wrong length, non-hex), a <code>WARNING</code> is logged and the agent falls back to ephemeral.</p>
+
+  <h2>Relay publishing — NIP-01 WebSocket flow</h2>
+  <p>Publishing uses a bare <code>aiohttp</code> WebSocket client — no external relay manager library. <strong>python-nostr's <code>RelayManager</code> is not used</strong> because it fails to import under Python 3.13 due to a mutable dataclass default in <code>nostr.relay</code>.</p>
+
+  <div class="nip-flow">
+<span class="nip-comment">Client                          Relay</span>
+  <span class="nip-send">──  ws://relay.damus.io  ──────────────────&gt;</span>
+  <span class="nip-send">──  ["EVENT", { id, pubkey, kind: 30078, </span>
+  <span class="nip-send">       tags: [["t","bitagent"],[...]], </span>
+  <span class="nip-send">       content: "{agent_id, endpoint, ...}",</span>
+  <span class="nip-send">       sig }]  ─────────────────────────────&gt;</span>
+  <span class="nip-recv">                       &lt;────  ["OK", id, true, ""]</span></div>
+
+  <p>All 5 relays are queried concurrently via <code>asyncio.gather</code>. Failures are logged at DEBUG and do not block startup.</p>
+
+  <div class="relay-list">
+    <span class="relay-chip">wss://relay.damus.io</span>
+    <span class="relay-chip">wss://relay.snort.social</span>
+    <span class="relay-chip">wss://nos.lol</span>
+    <span class="relay-chip">wss://nostr.wine</span>
+    <span class="relay-chip">wss://relay.nostr.band</span>
+  </div>
+
+  <h2>Relay querying — REQ / EOSE</h2>
+  <p>The <code>_ws_query</code> helper sends a NIP-01 <code>REQ</code> message and collects <code>EVENT</code> responses until the relay signals end-of-stored-events (<code>EOSE</code>) or a 5-second timeout expires.</p>
+
+  <div class="nip-flow">
+<span class="nip-send">──  ["REQ", "sub_abc123", </span>
+<span class="nip-send">      {"kinds":[30078], "since":1747000000,</span>
+<span class="nip-send">       "#t":["bitagent","agent-discovery"]}]  ──&gt;</span>
+
+<span class="nip-recv">    &lt;──  ["EVENT", "sub_abc123", { ...agent event... }]</span>
+<span class="nip-recv">    &lt;──  ["EVENT", "sub_abc123", { ...agent event... }]</span>
+<span class="nip-recv">    &lt;──  ["EOSE",  "sub_abc123"]</span>
+
+<span class="nip-send">──  ["CLOSE", "sub_abc123"]  ───────────────────────&gt;</span></div>
+
+  <h2>Agent registry endpoint</h2>
+  <p>Locally known agents are exposed over HTTP so clients don't need to subscribe to Nostr directly. See the <a href="api.html#registry" style="color: var(--orange);">API reference</a> for full details.</p>
+  <pre><span style="color:#8b949e"># List all known agents</span>
+GET /agents/registry
+
+<span style="color:#8b949e"># Filter by service capability</span>
+GET /agents/registry?service=search.query
+
+<span style="color:#8b949e"># Paginate</span>
+GET /agents/registry?limit=10&amp;offset=20</pre>
+
+  <h2>Decentralised Identity (DID)</h2>
+  <p>BitAgent supports four DID methods for agent identity documents. DIDs provide a cryptographically verifiable identifier that doesn't depend on a central registrar.</p>
+
+  <div class="identity-grid">
+    <div class="did-card">
+      <div class="method">did:key</div>
+      <p>Self-contained. The public key is encoded directly in the DID string. No external resolution needed.</p>
+    </div>
+    <div class="did-card">
+      <div class="method">did:web</div>
+      <p>Resolves to a JSON document at <code>https://domain/.well-known/did.json</code>. Ties identity to a domain.</p>
+    </div>
+    <div class="did-card">
+      <div class="method">did:bitcoin</div>
+      <p>Anchored to the Bitcoin blockchain. Suitable for agents that need on-chain provenance.</p>
+    </div>
+    <div class="did-card">
+      <div class="method">did:nostr</div>
+      <p>Resolves via Nostr pubkey. Natural fit for agents already using Nostr for discovery.</p>
+    </div>
+  </div>
+
+  <h2>NIP-05 identity</h2>
+  <p>The <strong>IdentityAgent</strong> registers human-readable Nostr identifiers of the form <code>name@domain</code>. Registration costs 10–1000 sats and creates a record in SQLite. The <code>/.well-known/nostr.json</code> endpoint then resolves the name to a pubkey — which is what NIP-05-compatible Nostr clients use to verify identity.</p>
+  <pre><span style="color:#8b949e"># Resolve alice@bitagent-production.up.railway.app</span>
+GET /.well-known/nostr.json?name=alice
+
+{
+  "names": { "alice": "npub_hex..." },
+  "relays": { "npub_hex...": ["wss://relay.damus.io"] }
+}</pre>
+
+  <h2>Trust scoring</h2>
+  <p>Each registered pubkey accumulates a trust score in <code>[0.0, 1.0]</code>. The score is deterministic and factors in payment history, account age, and activity. It's used as a gate for <code>streamfinder.search</code> when <code>IDENTITY_REQUIRE_FOR_PAID_SERVICES=true</code>.</p>
+  <pre><span style="color:#8b949e"># Get trust signal for a pubkey</span>
+POST /a2a
+{
+  "method": "identity.get_trust_signal",
+  "params": { "pubkey": "&lt;npub_hex&gt;" }
+}
+
+<span style="color:#3fb950">200</span>
+{ "trust_score": 0.72, "warning": null }</pre>
+
+</div>
+
+<footer>
+  <p>BitAgent · <a href="https://github.com/intrinsicinvestment91/bitagent" target="_blank">GitHub</a> · <a href="https://bitagent-production.up.railway.app/docs" target="_blank">Live API</a> · MIT License</p>
+</footer>
+
+</body>
+</html>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1,0 +1,332 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BitAgent — Lightning-Enabled AI Agents</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:       #0d1117;
+      --surface:  #161b22;
+      --border:   #30363d;
+      --orange:   #f7931a;
+      --orange-d: #d4781a;
+      --text:     #e6edf3;
+      --muted:    #8b949e;
+      --green:    #3fb950;
+      --purple:   #a371f7;
+      --blue:     #58a6ff;
+      --font:     -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      --mono:     "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    }
+
+    body { background: var(--bg); color: var(--text); font-family: var(--font); line-height: 1.6; }
+
+    /* NAV */
+    nav {
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      padding: 0 2rem;
+      display: flex;
+      align-items: center;
+      gap: 2rem;
+      height: 56px;
+      position: sticky;
+      top: 0;
+      z-index: 100;
+    }
+    nav .logo { font-weight: 700; font-size: 1.1rem; color: var(--orange); text-decoration: none; letter-spacing: -0.3px; }
+    nav a { color: var(--muted); text-decoration: none; font-size: 0.9rem; transition: color 0.15s; }
+    nav a:hover, nav a.active { color: var(--text); }
+    nav .spacer { flex: 1; }
+    nav .badge {
+      background: var(--orange);
+      color: #000;
+      font-size: 0.7rem;
+      font-weight: 700;
+      padding: 2px 8px;
+      border-radius: 99px;
+      text-decoration: none;
+    }
+
+    /* HERO */
+    .hero {
+      max-width: 860px;
+      margin: 6rem auto 4rem;
+      padding: 0 2rem;
+      text-align: center;
+    }
+    .hero .tag {
+      display: inline-block;
+      border: 1px solid var(--orange);
+      color: var(--orange);
+      font-size: 0.75rem;
+      font-weight: 600;
+      padding: 3px 12px;
+      border-radius: 99px;
+      letter-spacing: 0.8px;
+      text-transform: uppercase;
+      margin-bottom: 1.5rem;
+    }
+    .hero h1 { font-size: clamp(2rem, 5vw, 3.2rem); font-weight: 700; letter-spacing: -1px; line-height: 1.15; margin-bottom: 1.2rem; }
+    .hero h1 span { color: var(--orange); }
+    .hero p { font-size: 1.15rem; color: var(--muted); max-width: 600px; margin: 0 auto 2.5rem; }
+    .hero-cta { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+    .btn {
+      display: inline-block;
+      padding: 0.65rem 1.5rem;
+      border-radius: 6px;
+      font-size: 0.9rem;
+      font-weight: 600;
+      text-decoration: none;
+      transition: opacity 0.15s;
+    }
+    .btn:hover { opacity: 0.85; }
+    .btn-primary { background: var(--orange); color: #000; }
+    .btn-secondary { background: var(--surface); color: var(--text); border: 1px solid var(--border); }
+
+    /* STATS */
+    .stats {
+      display: flex;
+      justify-content: center;
+      gap: 3rem;
+      flex-wrap: wrap;
+      padding: 2.5rem 2rem;
+      border-top: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+      background: var(--surface);
+    }
+    .stat { text-align: center; }
+    .stat .num { font-size: 1.9rem; font-weight: 700; color: var(--orange); }
+    .stat .label { font-size: 0.8rem; color: var(--muted); margin-top: 2px; }
+
+    /* SECTIONS */
+    section { max-width: 1000px; margin: 0 auto; padding: 4rem 2rem; }
+    section h2 { font-size: 1.6rem; font-weight: 700; letter-spacing: -0.4px; margin-bottom: 0.5rem; }
+    section .sub { color: var(--muted); margin-bottom: 2rem; font-size: 0.95rem; }
+
+    /* FEATURE GRID */
+    .feature-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1rem; }
+    .feature-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1.5rem;
+      transition: border-color 0.2s;
+    }
+    .feature-card:hover { border-color: var(--orange); }
+    .feature-card .icon { font-size: 1.5rem; margin-bottom: 0.75rem; }
+    .feature-card h3 { font-size: 1rem; font-weight: 600; margin-bottom: 0.4rem; }
+    .feature-card p { font-size: 0.875rem; color: var(--muted); }
+
+    /* AGENT PREVIEW */
+    .agent-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1rem 1.25rem;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      margin-bottom: 0.5rem;
+      text-decoration: none;
+      color: var(--text);
+      transition: border-color 0.15s;
+    }
+    .agent-row:hover { border-color: var(--orange); }
+    .agent-row .name { font-weight: 600; font-size: 0.95rem; }
+    .agent-row .desc { font-size: 0.82rem; color: var(--muted); margin-top: 2px; }
+    .agent-row .price {
+      font-family: var(--mono);
+      font-size: 0.8rem;
+      color: var(--orange);
+      background: rgba(247,147,26,0.1);
+      padding: 3px 10px;
+      border-radius: 99px;
+      white-space: nowrap;
+    }
+
+    /* CODE */
+    pre {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1.25rem 1.5rem;
+      overflow-x: auto;
+      font-family: var(--mono);
+      font-size: 0.82rem;
+      line-height: 1.6;
+    }
+    code { font-family: var(--mono); font-size: 0.85em; color: var(--orange); background: rgba(247,147,26,0.1); padding: 1px 5px; border-radius: 3px; }
+
+    /* FLOW DIAGRAM */
+    .flow {
+      display: flex;
+      align-items: center;
+      gap: 0;
+      flex-wrap: wrap;
+      margin: 1.5rem 0;
+    }
+    .flow-step {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 0.6rem 1rem;
+      font-size: 0.82rem;
+      font-weight: 500;
+    }
+    .flow-arrow { color: var(--muted); padding: 0 0.5rem; font-size: 1rem; }
+
+    /* FOOTER */
+    footer {
+      border-top: 1px solid var(--border);
+      padding: 2rem;
+      text-align: center;
+      color: var(--muted);
+      font-size: 0.8rem;
+    }
+    footer a { color: var(--muted); text-decoration: none; }
+    footer a:hover { color: var(--text); }
+  </style>
+</head>
+<body>
+
+<nav>
+  <a class="logo" href="index.html">⚡ BitAgent</a>
+  <a href="index.html" class="active">Overview</a>
+  <a href="agents.html">Agents</a>
+  <a href="architecture.html">Architecture</a>
+  <a href="payments.html">Payments</a>
+  <a href="discovery.html">Discovery</a>
+  <a href="api.html">API</a>
+  <span class="spacer"></span>
+  <a class="badge" href="https://bitagent-production.up.railway.app/docs" target="_blank">Live Docs ↗</a>
+</nav>
+
+<div class="hero">
+  <div class="tag">Open Source · Bitcoin Native</div>
+  <h1>AI agents that <span>earn and spend</span><br>Bitcoin automatically</h1>
+  <p>BitAgent is a modular framework for autonomous AI agents that offer services, accept Lightning payments, discover each other over Nostr, and verify identity with DIDs.</p>
+  <div class="hero-cta">
+    <a href="agents.html" class="btn btn-primary">Explore Agents</a>
+    <a href="architecture.html" class="btn btn-secondary">How It Works</a>
+  </div>
+</div>
+
+<div class="stats">
+  <div class="stat"><div class="num">7</div><div class="label">Live Agents</div></div>
+  <div class="stat"><div class="num">2 sats</div><div class="label">Lowest price</div></div>
+  <div class="stat"><div class="num">2</div><div class="label">Payment paths (Lightning + ecash)</div></div>
+  <div class="stat"><div class="num">5</div><div class="label">Nostr relays</div></div>
+  <div class="stat"><div class="num">4</div><div class="label">DID methods</div></div>
+</div>
+
+<section>
+  <h2>What is BitAgent?</h2>
+  <p class="sub">A framework for building autonomous AI agents with native Bitcoin payments.</p>
+  <div class="feature-grid">
+    <div class="feature-card">
+      <div class="icon">⚡</div>
+      <h3>Lightning Payments</h3>
+      <p>Every agent issues Lightning invoices and verifies payment before serving requests. No accounts, no API keys — pay per use.</p>
+    </div>
+    <div class="feature-card">
+      <div class="icon">🔍</div>
+      <h3>Nostr Discovery</h3>
+      <p>Agents broadcast their capabilities as Nostr Kind 30078 events. Any client or agent can discover services without a central registry.</p>
+    </div>
+    <div class="feature-card">
+      <div class="icon">🪪</div>
+      <h3>Decentralised Identity</h3>
+      <p>Agents verify identity using DIDs (did:key, did:web, did:bitcoin, did:nostr) and NIP-05 handles with trust scoring.</p>
+    </div>
+    <div class="feature-card">
+      <div class="icon">🤖</div>
+      <h3>Agent-to-Agent (A2A)</h3>
+      <p>Agents call each other over a JSON-RPC protocol. A coordinator agent chains multiple specialists into multi-step workflows.</p>
+    </div>
+    <div class="feature-card">
+      <div class="icon">🛠️</div>
+      <h3>Claude MCP Integration</h3>
+      <p>Exposed as Claude tools via MCP stdio server. Claude can search the web, get prices, fetch URLs, and translate — all paid in sats.</p>
+    </div>
+    <div class="feature-card">
+      <div class="icon">🌿</div>
+      <h3>Fedimint Ecash</h3>
+      <p>A second payment path alongside Lightning. Agents accept ecash notes, validate them non-destructively, then reissue into the federation wallet.</p>
+    </div>
+  </div>
+</section>
+
+<section>
+  <h2>Request lifecycle</h2>
+  <p class="sub">Every paid endpoint follows the same 402 → pay → resubmit flow.</p>
+  <div class="flow">
+    <div class="flow-step">Client sends request</div>
+    <div class="flow-arrow">→</div>
+    <div class="flow-step">No payment_hash?<br>Return 402 + invoice</div>
+    <div class="flow-arrow">→</div>
+    <div class="flow-step">Client pays invoice</div>
+    <div class="flow-arrow">→</div>
+    <div class="flow-step">Resubmit with payment_hash</div>
+    <div class="flow-arrow">→</div>
+    <div class="flow-step">Agent verifies + serves</div>
+  </div>
+  <pre>
+<span style="color:#8b949e"># 1. First request → 402</span>
+POST /search
+{}
+
+HTTP 402
+{ "invoice": "lnbc100n1p...", "amount_sats": 10 }
+
+<span style="color:#8b949e"># 2. Pay invoice, then resubmit</span>
+POST /search
+{ "query": "bitcoin price", "payment_hash": "1b741d85..." }
+
+HTTP 200
+{ "results": [...], "cost_sats": 10 }</pre>
+</section>
+
+<section>
+  <h2>Live agents</h2>
+  <p class="sub">All agents are running on Railway at <code>bitagent-production.up.railway.app</code>.</p>
+
+  <a href="agents.html#polyglot" class="agent-row">
+    <div><div class="name">PolyglotAgent</div><div class="desc">Translation and audio transcription</div></div>
+    <div class="price">100–250 sats</div>
+  </a>
+  <a href="agents.html#coordinator" class="agent-row">
+    <div><div class="name">CoordinatorAgent</div><div class="desc">Multi-agent workflow orchestration</div></div>
+    <div class="price">350 sats</div>
+  </a>
+  <a href="agents.html#oracle" class="agent-row">
+    <div><div class="name">PriceOracleAgent</div><div class="desc">Crypto prices via CoinGecko / Binance</div></div>
+    <div class="price">2 sats</div>
+  </a>
+  <a href="agents.html#fetch" class="agent-row">
+    <div><div class="name">WebFetchAgent</div><div class="desc">Fetch web content with SSRF protection</div></div>
+    <div class="price">25 sats</div>
+  </a>
+  <a href="agents.html#search" class="agent-row">
+    <div><div class="name">SearchAgent</div><div class="desc">Web search: Brave → SearXNG → DuckDuckGo</div></div>
+    <div class="price">10 sats</div>
+  </a>
+  <a href="agents.html#streamfinder" class="agent-row">
+    <div><div class="name">StreamfinderAgent</div><div class="desc">A2A JSON-RPC reference implementation</div></div>
+    <div class="price">100 sats</div>
+  </a>
+  <a href="agents.html#identity" class="agent-row">
+    <div><div class="name">IdentityAgent</div><div class="desc">NIP-05 registration and trust scoring</div></div>
+    <div class="price">10–1000 sats</div>
+  </a>
+</section>
+
+<footer>
+  <p>BitAgent · <a href="https://github.com/intrinsicinvestment91/bitagent" target="_blank">GitHub</a> · <a href="https://bitagent-production.up.railway.app/docs" target="_blank">Live API</a> · MIT License</p>
+</footer>
+
+</body>
+</html>

--- a/docs/site/payments.html
+++ b/docs/site/payments.html
@@ -1,0 +1,296 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Payments — BitAgent</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #0d1117; --surface: #161b22; --border: #30363d;
+      --orange: #f7931a; --text: #e6edf3; --muted: #8b949e;
+      --green: #3fb950; --blue: #58a6ff; --purple: #a371f7;
+      --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      --mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    }
+    body { background: var(--bg); color: var(--text); font-family: var(--font); line-height: 1.6; }
+    nav {
+      background: var(--surface); border-bottom: 1px solid var(--border);
+      padding: 0 2rem; display: flex; align-items: center; gap: 2rem;
+      height: 56px; position: sticky; top: 0; z-index: 100;
+    }
+    nav .logo { font-weight: 700; font-size: 1.1rem; color: var(--orange); text-decoration: none; }
+    nav a { color: var(--muted); text-decoration: none; font-size: 0.9rem; }
+    nav a:hover, nav a.active { color: var(--text); }
+    nav .spacer { flex: 1; }
+    nav .badge { background: var(--orange); color: #000; font-size: 0.7rem; font-weight: 700; padding: 2px 8px; border-radius: 99px; text-decoration: none; }
+
+    .page-header { max-width: 900px; margin: 3rem auto 0; padding: 0 2rem 2rem; border-bottom: 1px solid var(--border); }
+    .page-header h1 { font-size: 2rem; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 0.4rem; }
+    .page-header p { color: var(--muted); }
+
+    .content { max-width: 900px; margin: 0 auto; padding: 3rem 2rem; }
+    h2 { font-size: 1.35rem; font-weight: 700; letter-spacing: -0.3px; margin: 2.5rem 0 0.4rem; }
+    h2:first-child { margin-top: 0; }
+    p { color: var(--muted); font-size: 0.92rem; margin-bottom: 1rem; }
+    p strong { color: var(--text); }
+
+    .path-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; margin: 1.5rem 0; }
+    @media (max-width: 600px) { .path-grid { grid-template-columns: 1fr; } }
+    .path-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 1.75rem;
+    }
+    .path-card .path-badge {
+      display: inline-block;
+      font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px;
+      padding: 2px 10px; border-radius: 99px; margin-bottom: 1rem;
+    }
+    .path-card.lightning .path-badge { background: rgba(247,147,26,0.15); color: var(--orange); border: 1px solid var(--orange); }
+    .path-card.ecash .path-badge { background: rgba(163,113,247,0.15); color: var(--purple); border: 1px solid var(--purple); }
+    .path-card h3 { font-size: 1.1rem; font-weight: 700; margin-bottom: 0.4rem; }
+    .path-card p { font-size: 0.85rem; color: var(--muted); }
+    .path-card ul { list-style: none; margin-top: 0.75rem; }
+    .path-card li { font-size: 0.83rem; color: var(--muted); padding: 3px 0; }
+    .path-card.lightning li::before { content: "⚡ "; }
+    .path-card.ecash li::before { content: "🍃 "; }
+
+    .flow-box {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 8px; padding: 1.5rem 2rem; margin: 1.25rem 0;
+    }
+    .flow-step { display: flex; align-items: flex-start; gap: 1rem; margin-bottom: 1rem; }
+    .flow-step:last-child { margin-bottom: 0; }
+    .step-num {
+      background: var(--orange); color: #000;
+      font-size: 0.72rem; font-weight: 700;
+      width: 22px; height: 22px;
+      border-radius: 50%; display: flex; align-items: center; justify-content: center;
+      flex-shrink: 0; margin-top: 2px;
+    }
+    .step-text h4 { font-size: 0.9rem; font-weight: 600; margin-bottom: 2px; }
+    .step-text p { font-size: 0.82rem; color: var(--muted); margin: 0; }
+
+    pre {
+      background: var(--bg); border: 1px solid var(--border);
+      border-radius: 8px; padding: 1rem 1.25rem; overflow-x: auto;
+      font-family: var(--mono); font-size: 0.78rem; line-height: 1.65;
+      margin: 1rem 0;
+    }
+    code { font-family: var(--mono); font-size: 0.84em; color: var(--orange); background: rgba(247,147,26,0.1); padding: 1px 5px; border-radius: 3px; }
+
+    table { width: 100%; border-collapse: collapse; font-size: 0.85rem; margin: 1rem 0; }
+    th { text-align: left; padding: 0.6rem 1rem; border-bottom: 2px solid var(--border); color: var(--muted); font-weight: 600; font-size: 0.72rem; text-transform: uppercase; }
+    td { padding: 0.6rem 1rem; border-bottom: 1px solid var(--border); }
+    tr:last-child td { border-bottom: none; }
+
+    .callout {
+      background: rgba(247,147,26,0.07); border: 1px solid rgba(247,147,26,0.3);
+      border-radius: 8px; padding: 1rem 1.25rem; font-size: 0.85rem;
+      color: var(--text); margin: 1.25rem 0;
+    }
+    .callout strong { color: var(--orange); }
+
+    footer { border-top: 1px solid var(--border); padding: 2rem; text-align: center; color: var(--muted); font-size: 0.8rem; }
+    footer a { color: var(--muted); text-decoration: none; }
+  </style>
+</head>
+<body>
+
+<nav>
+  <a class="logo" href="index.html">⚡ BitAgent</a>
+  <a href="index.html">Overview</a>
+  <a href="agents.html">Agents</a>
+  <a href="architecture.html">Architecture</a>
+  <a href="payments.html" class="active">Payments</a>
+  <a href="discovery.html">Discovery</a>
+  <a href="api.html">API</a>
+  <span class="spacer"></span>
+  <a class="badge" href="https://bitagent-production.up.railway.app/docs" target="_blank">Live Docs ↗</a>
+</nav>
+
+<div class="page-header">
+  <h1>Payments</h1>
+  <p>Two independent payment paths: Lightning Network (LNbits) and Fedimint ecash.</p>
+</div>
+
+<div class="content">
+
+  <h2>Two payment paths</h2>
+  <p>Agents accept both Lightning invoices and Fedimint ecash notes. The paths are completely independent — a client can use either without the other being configured.</p>
+
+  <div class="path-grid">
+    <div class="path-card lightning">
+      <div class="path-badge">Lightning</div>
+      <h3>⚡ LNbits</h3>
+      <p>The primary payment path. Every agent endpoint returns a bolt11 invoice on a 402 response. The client pays, then resubmits with the <code>payment_hash</code>.</p>
+      <ul>
+        <li>Real payments verified in production</li>
+        <li>Live wallet: ~68k sats</li>
+        <li>Backed by LNbits REST API</li>
+        <li>Requires LNBITS_URL + LNBITS_API_KEY</li>
+      </ul>
+    </div>
+    <div class="path-card ecash">
+      <div class="path-badge">Ecash</div>
+      <h3>🍃 Fedimint</h3>
+      <p>An additive second path. Agents accept <code>ecash_notes</code> alongside <code>payment_hash</code>. The notes are validated non-destructively first, then reissued into the federation wallet.</p>
+      <ul>
+        <li>Live in production alongside Lightning</li>
+        <li>Backed by fedimint-clientd HTTP API</li>
+        <li>Requires FEDIMINT_CLIENTD_URL + password</li>
+        <li>Gracefully disabled if not configured</li>
+      </ul>
+    </div>
+  </div>
+
+  <h2>Lightning payment flow</h2>
+  <div class="flow-box">
+    <div class="flow-step">
+      <div class="step-num">1</div>
+      <div class="step-text">
+        <h4>Client sends request without payment</h4>
+        <p>Any POST to a paid endpoint without <code>payment_hash</code> returns HTTP 402.</p>
+      </div>
+    </div>
+    <div class="flow-step">
+      <div class="step-num">2</div>
+      <div class="step-text">
+        <h4>Agent issues a Lightning invoice</h4>
+        <p>402 response includes a bolt11 invoice and the <code>amount_sats</code>. If Fedimint is enabled, also includes <code>ecash_accepted: true</code> and <code>ecash_amount_msats</code>.</p>
+      </div>
+    </div>
+    <div class="flow-step">
+      <div class="step-num">3</div>
+      <div class="step-text">
+        <h4>Client pays the invoice</h4>
+        <p>Any Lightning wallet can pay. The <code>payment_hash</code> is derived from the bolt11 string.</p>
+      </div>
+    </div>
+    <div class="flow-step">
+      <div class="step-num">4</div>
+      <div class="step-text">
+        <h4>Client resubmits with payment_hash</h4>
+        <p>The agent calls <code>AgentWallet.check_invoice(payment_hash)</code>. On success it runs the service and returns the result with <code>cost_sats</code>.</p>
+      </div>
+    </div>
+  </div>
+
+  <pre><span style="color:#8b949e"># Step 1 — no payment_hash → 402</span>
+curl -X POST https://bitagent-production.up.railway.app/search/search \
+  -d '{"query": "bitcoin"}'
+
+<span style="color:#3fb950">HTTP 402</span>
+{
+  "invoice": "lnbc100n1p4q3ala...",
+  "amount_sats": 10,
+  "ecash_accepted": true,
+  "ecash_amount_msats": 10000
+}
+
+<span style="color:#8b949e"># Step 2 — pay, then resubmit</span>
+curl -X POST https://bitagent-production.up.railway.app/search/search \
+  -d '{
+    "query": "bitcoin",
+    "payment_hash": "1b741d85..."
+  }'
+
+<span style="color:#3fb950">HTTP 200</span>
+{ "results": [...], "cost_sats": 10 }</pre>
+
+  <h2>Fedimint ecash flow</h2>
+  <p>The ecash path uses a <strong>validate → reissue</strong> two-step to avoid double-spend without sacrificing speed.</p>
+  <div class="flow-box">
+    <div class="flow-step">
+      <div class="step-num">1</div>
+      <div class="step-text">
+        <h4>Client sends ecash_notes</h4>
+        <p>Include <code>ecash_notes</code> in the request body instead of (or alongside) <code>payment_hash</code>.</p>
+      </div>
+    </div>
+    <div class="flow-step">
+      <div class="step-num">2</div>
+      <div class="step-text">
+        <h4>Agent validates (non-destructive)</h4>
+        <p><code>FedimintWallet.validate(notes, amount_msats)</code> checks the notes against the federation without redeeming them. Returns <code>True/False</code>.</p>
+      </div>
+    </div>
+    <div class="flow-step">
+      <div class="step-num">3</div>
+      <div class="step-text">
+        <h4>Agent reissues (destructive)</h4>
+        <p>On successful validation, <code>FedimintWallet.reissue(notes)</code> redeems the notes into the federation wallet. This is the point of no return.</p>
+      </div>
+    </div>
+    <div class="flow-step">
+      <div class="step-num">4</div>
+      <div class="step-text">
+        <h4>Service is run</h4>
+        <p>Same result as Lightning path. Response includes <code>cost_sats</code>.</p>
+      </div>
+    </div>
+  </div>
+
+  <h2>Wallet tiers</h2>
+  <table>
+    <thead><tr><th>Wallet</th><th>Location</th><th>Required config</th><th>Used by</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>_SimWallet</td>
+        <td>src/agents/base_agent.py</td>
+        <td>None</td>
+        <td>BaseAgent subclasses, examples, tests — in-memory, no real payments</td>
+      </tr>
+      <tr>
+        <td>AgentWallet</td>
+        <td>agent_wallet.py</td>
+        <td>LNBITS_URL, LNBITS_API_KEY</td>
+        <td>All live agents — lazy loaded, raises if config missing</td>
+      </tr>
+      <tr>
+        <td>FedimintWallet</td>
+        <td>src/wallets/fedimint_wallet.py</td>
+        <td>FEDIMINT_CLIENTD_URL, FEDIMINT_CLIENTD_PASSWORD</td>
+        <td>All live agents — eagerly instantiated, disabled gracefully if unconfigured</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout">
+    <strong>Important:</strong> The <code>@require_payment</code> decorator in <code>src/core/payment.py</code> uses an incompatible escrow/<code>PaymentSecurityManager</code> system and is <strong>not wired to the real LNbits wallet</strong>. Do not use it. All live agents implement payment checks inline.
+  </div>
+
+  <h2>Agent prices</h2>
+  <table>
+    <thead><tr><th>Agent</th><th>Price</th><th>Per</th></tr></thead>
+    <tbody>
+      <tr><td>PriceOracleAgent</td><td>2 sats</td><td>request</td></tr>
+      <tr><td>SearchAgent</td><td>10 sats</td><td>query</td></tr>
+      <tr><td>IdentityAgent</td><td>10–1000 sats</td><td>operation</td></tr>
+      <tr><td>WebFetchAgent</td><td>25 sats</td><td>URL</td></tr>
+      <tr><td>StreamfinderAgent</td><td>100 sats</td><td>request</td></tr>
+      <tr><td>PolyglotAgent (translate)</td><td>100 sats</td><td>request</td></tr>
+      <tr><td>PolyglotAgent (transcribe)</td><td>250 sats</td><td>request</td></tr>
+      <tr><td>CoordinatorAgent</td><td>350 sats</td><td>workflow</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Environment variables</h2>
+  <pre><span style="color:#8b949e"># Required for Lightning payments</span>
+LNBITS_URL=https://your-lnbits-instance.com
+LNBITS_API_KEY=your_lnbits_invoice_key
+
+<span style="color:#8b949e"># Optional — Fedimint ecash (second payment path)</span>
+FEDIMINT_CLIENTD_URL=http://localhost:3333
+FEDIMINT_CLIENTD_PASSWORD=your_password</pre>
+
+</div>
+
+<footer>
+  <p>BitAgent · <a href="https://github.com/intrinsicinvestment91/bitagent" target="_blank">GitHub</a> · <a href="https://bitagent-production.up.railway.app/docs" target="_blank">Live API</a> · MIT License</p>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Move six standalone HTML files (`index`, `agents`, `architecture`, `payments`, `discovery`, `api`) from the repo root into `docs/site/`
- Add `docs/site/README.md` explaining the pages and that no build step is required
- No application code modified

## Test plan

- [ ] Open `docs/site/index.html` directly in a browser — page renders without a server
- [ ] Confirm all six page links resolve correctly within the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)